### PR TITLE
Custom sizes of graphical elements

### DIFF
--- a/interface/config_parameters.cpp
+++ b/interface/config_parameters.cpp
@@ -32,7 +32,10 @@ ConfigParameters::ConfigParameters()
     , bettiDotRadius(5) //radius of dot representing xi_0 = 1 or xi_1 = 1
     , persistenceDotRadius(5) //radius of dot representing one homology class in persistence diagram
     , autoDotSize(true) //automatic dot sizing is initially on
+    , sliceLineWidth(5) //width of selected line (pixels)
+    , persistenceBarWidth(4) //width of persistence bars (pixels)
+    , persistenceBarSpace(5) //space between persistence bars(pixels)
     , diagramFont() //system default font
 {
-    diagramFont.setPointSize(14);   // SET DEFAULT FONT SIZE HERE
+    diagramFont.setPointSize(12);   // SET DEFAULT FONT SIZE HERE
 }

--- a/interface/config_parameters.cpp
+++ b/interface/config_parameters.cpp
@@ -22,24 +22,17 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 //default values are set here
 ConfigParameters::ConfigParameters()
-    : xi0color(0, 255, 0, 100)
-    , //green semi-transparent, for xi_0 support dots
-    xi1color(255, 0, 0, 100)
-    , //red semi-transparent, for xi_1 support dots
-    xi2color(255, 255, 0, 100)
-    , //yellow semi-transparent, for xi_2 support dots
-    persistenceColor(160, 0, 200, 127)
-    , //purple semi-transparent, for persistence bars and dots
-    persistenceHighlightColor(255, 140, 0, 150)
-    , //orange semi-transparent, for highlighting part of the slice line
-    sliceLineColor(0, 0, 255, 150)
-    , //blue semi-transparent, for slice line
-    sliceLineHighlightColor(0, 200, 200, 150)
-    , //cyan semi-transparent, for highlighting the slice line on click-and-drag
-    bettiDotRadius(5)
-    , //radius of dot representing xi_0 = 1 or xi_1 = 1
-    persistenceDotRadius(5)
-    , //radius of dot representing one homology class in persistence diagram
-    autoDotSize(true) //automatic dot sizing is initially on
+    : xi0color(0, 255, 0, 100) //green semi-transparent, for xi_0 support dots
+    , xi1color(255, 0, 0, 100) //red semi-transparent, for xi_1 support dots
+    , xi2color(255, 255, 0, 100) //yellow semi-transparent, for xi_2 support dots
+    , persistenceColor(160, 0, 200, 127) //purple semi-transparent, for persistence bars and dots
+    , persistenceHighlightColor(255, 140, 0, 150) //orange semi-transparent, for highlighting part of the slice line
+    , sliceLineColor(0, 0, 255, 150) //blue semi-transparent, for slice line
+    , sliceLineHighlightColor(0, 200, 200, 150) //cyan semi-transparent, for highlighting the slice line on click-and-drag
+    , bettiDotRadius(5) //radius of dot representing xi_0 = 1 or xi_1 = 1
+    , persistenceDotRadius(5) //radius of dot representing one homology class in persistence diagram
+    , autoDotSize(true) //automatic dot sizing is initially on
+    , diagramFont() //system default font
 {
+    diagramFont.setPointSize(14);   // SET DEFAULT FONT SIZE HERE
 }

--- a/interface/config_parameters.h
+++ b/interface/config_parameters.h
@@ -22,6 +22,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define CONFIG_PARAMETERS_H
 
 #include <QColor>
+#include <QFont>
 
 //these parameters control the visualization and are (mostly) user-customizable through the Configure dialog box
 struct ConfigParameters {
@@ -38,6 +39,9 @@ struct ConfigParameters {
     int bettiDotRadius;
     int persistenceDotRadius;
     bool autoDotSize;
+
+    //fonts
+    QFont diagramFont;
 
     //constructor
     ConfigParameters();

--- a/interface/config_parameters.h
+++ b/interface/config_parameters.h
@@ -23,6 +23,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #include <QColor>
 #include <QFont>
+#include <QString>
 
 //these parameters control the visualization and are (mostly) user-customizable through the Configure dialog box
 struct ConfigParameters {
@@ -42,6 +43,10 @@ struct ConfigParameters {
     int sliceLineWidth;
     int persistenceBarWidth;
     int persistenceBarSpace;
+
+    //text
+    QString xLabel;
+    QString yLabel;
 
     //fonts
     QFont diagramFont;

--- a/interface/config_parameters.h
+++ b/interface/config_parameters.h
@@ -39,6 +39,9 @@ struct ConfigParameters {
     int bettiDotRadius;
     int persistenceDotRadius;
     bool autoDotSize;
+    int sliceLineWidth;
+    int persistenceBarWidth;
+    int persistenceBarSpace;
 
     //fonts
     QFont diagramFont;

--- a/interface/configuredialog.cpp
+++ b/interface/configuredialog.cpp
@@ -41,8 +41,6 @@ ConfigureDialog::ConfigureDialog(ConfigParameters& c_params, InputParameters& i_
     , bettiRadius(config_params.bettiDotRadius)
     , perRadius(config_params.persistenceDotRadius)
     , autoDots(config_params.autoDotSize)
-    , xlabel(QString::fromStdString(input_params.x_label))
-    , ylabel(QString::fromStdString(input_params.y_label))
     , dgmFont(config_params.diagramFont)
 {
     ui->setupUi(this);
@@ -107,8 +105,8 @@ ConfigureDialog::ConfigureDialog(ConfigParameters& c_params, InputParameters& i_
     ui->barSpacingSpinBox->setValue(config_params.persistenceBarSpace);
 
     //set labels to current labels
-    ui->xaxisText->setText(xlabel);
-    ui->yaxisText->setText(ylabel);
+    ui->xaxisText->setText(config_params.xLabel);
+    ui->yaxisText->setText(config_params.yLabel);
 
     //set font properties
     ui->fontSizeSpinBox->setValue(dgmFont.pointSize());
@@ -143,10 +141,8 @@ void ConfigureDialog::on_okButton_clicked()
     config_params.persistenceBarWidth = ui->barWidthSpinBox->value();
     config_params.persistenceBarSpace = ui->barSpacingSpinBox->value();
     config_params.diagramFont = dgmFont;
-
-    //update axis labels in input_params
-    input_params.x_label = xlabel.toUtf8().constData();
-    input_params.y_label = ylabel.toUtf8().constData();
+    config_params.xLabel = ui->xaxisText->text();
+    config_params.yLabel = ui->yaxisText->text();
 
     //close the dialog box
     close();
@@ -333,16 +329,6 @@ void ConfigureDialog::on_bettiDotSpinBox_valueChanged(int arg1)
 void ConfigureDialog::on_persistenceDotSpinBox_valueChanged(int arg1)
 {
     perRadius = arg1;
-}
-
-void ConfigureDialog::on_xaxisText_editingFinished()
-{
-    xlabel = ui->xaxisText->text();
-}
-
-void ConfigureDialog::on_yaxisText_editingFinished()
-{
-    ylabel = ui->yaxisText->text();
 }
 
 void ConfigureDialog::on_AutoDotSizeCheckBox_clicked(bool checked)

--- a/interface/configuredialog.cpp
+++ b/interface/configuredialog.cpp
@@ -43,6 +43,7 @@ ConfigureDialog::ConfigureDialog(ConfigParameters& c_params, InputParameters& i_
     , autoDots(config_params.autoDotSize)
     , xlabel(QString::fromStdString(input_params.x_label))
     , ylabel(QString::fromStdString(input_params.y_label))
+    , dgmFont(config_params.diagramFont)
 {
     ui->setupUi(this);
 
@@ -101,9 +102,17 @@ ConfigureDialog::ConfigureDialog(ConfigParameters& c_params, InputParameters& i_
         ui->persistenceDotSizeLabel->setEnabled(false);
     }
 
+    ui->lineWidthSpinBox->setValue(config_params.sliceLineWidth);
+    ui->barWidthSpinBox->setValue(config_params.persistenceBarWidth);
+    ui->barSpacingSpinBox->setValue(config_params.persistenceBarSpace);
+
     //set labels to current labels
     ui->xaxisText->setText(xlabel);
     ui->yaxisText->setText(ylabel);
+
+    //set font properties
+    ui->fontSizeSpinBox->setValue(dgmFont.pointSize());
+    ui->fontSample->setFont(dgmFont);
 
 } //end constructor
 
@@ -130,6 +139,10 @@ void ConfigureDialog::on_okButton_clicked()
     config_params.bettiDotRadius = bettiRadius;
     config_params.persistenceDotRadius = perRadius;
     config_params.autoDotSize = autoDots;
+    config_params.sliceLineWidth = ui->lineWidthSpinBox->value();
+    config_params.persistenceBarWidth = ui->barWidthSpinBox->value();
+    config_params.persistenceBarSpace = ui->barSpacingSpinBox->value();
+    config_params.diagramFont = dgmFont;
 
     //update axis labels in input_params
     input_params.x_label = xlabel.toUtf8().constData();
@@ -347,4 +360,10 @@ void ConfigureDialog::on_AutoDotSizeCheckBox_clicked(bool checked)
         ui->persistenceDotSpinBox->setEnabled(true);
         ui->persistenceDotSizeLabel->setEnabled(true);
     }
+}
+
+void ConfigureDialog::on_fontSizeSpinBox_valueChanged(int arg1)
+{
+    dgmFont.setPointSize(arg1);
+    ui->fontSample->setFont(dgmFont);
 }

--- a/interface/configuredialog.h
+++ b/interface/configuredialog.h
@@ -27,6 +27,7 @@ struct ConfigParameters;
 
 #include <QColor>
 #include <QDialog>
+#include <QFont>
 #include <QString>
 
 namespace Ui {
@@ -71,6 +72,8 @@ private slots:
 
     void on_AutoDotSizeCheckBox_clicked(bool checked);
 
+    void on_fontSizeSpinBox_valueChanged(int arg1);
+
 private:
     Ui::ConfigureDialog* ui;
     ConfigParameters& config_params;
@@ -89,6 +92,7 @@ private:
     bool autoDots;
     QString xlabel;
     QString ylabel;
+    QFont dgmFont;
 };
 
 #endif // CONFIGUREDIALOG_H

--- a/interface/configuredialog.h
+++ b/interface/configuredialog.h
@@ -66,10 +66,6 @@ private slots:
     void on_bettiDotSpinBox_valueChanged(int arg1);
     void on_persistenceDotSpinBox_valueChanged(int arg1);
 
-    void on_xaxisText_editingFinished();
-
-    void on_yaxisText_editingFinished();
-
     void on_AutoDotSizeCheckBox_clicked(bool checked);
 
     void on_fontSizeSpinBox_valueChanged(int arg1);
@@ -90,8 +86,6 @@ private:
     int bettiRadius;
     int perRadius;
     bool autoDots;
-    QString xlabel;
-    QString ylabel;
     QFont dgmFont;
 };
 

--- a/interface/configuredialog.ui
+++ b/interface/configuredialog.ui
@@ -10,6 +10,12 @@
     <height>420</height>
    </rect>
   </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
+  </property>
   <property name="windowTitle">
    <string>Configure RIVET</string>
   </property>
@@ -577,7 +583,7 @@
       </font>
      </property>
      <property name="text">
-      <string>Width of line selection (pixels):</string>
+      <string>Line selection width (pixels):</string>
      </property>
     </widget>
     <widget class="QLabel" name="barWidthLabel">

--- a/interface/configuredialog.ui
+++ b/interface/configuredialog.ui
@@ -38,6 +38,12 @@
        <height>17</height>
       </rect>
      </property>
+     <property name="font">
+      <font>
+       <weight>75</weight>
+       <bold>true</bold>
+      </font>
+     </property>
      <property name="text">
       <string>Select colors for the visualizations:</string>
      </property>
@@ -436,12 +442,18 @@
       <rect>
        <x>10</x>
        <y>10</y>
-       <width>221</width>
+       <width>281</width>
        <height>17</height>
       </rect>
      </property>
+     <property name="font">
+      <font>
+       <weight>75</weight>
+       <bold>true</bold>
+      </font>
+     </property>
      <property name="text">
-      <string>Radius for unit dots, in pixels:</string>
+      <string>Radius for unit dots (pixels):</string>
      </property>
     </widget>
     <widget class="QLabel" name="bettiDotSizeLabel">
@@ -454,7 +466,7 @@
       </rect>
      </property>
      <property name="text">
-      <string>Support points of multigraded Betti numbers</string>
+      <string>Support points of bigraded Betti numbers</string>
      </property>
     </widget>
     <widget class="QLabel" name="persistenceDotSizeLabel">
@@ -505,14 +517,131 @@
        <height>22</height>
       </rect>
      </property>
+     <property name="font">
+      <font>
+       <pointsize>11</pointsize>
+      </font>
+     </property>
      <property name="text">
       <string>Use automatic dot sizes</string>
      </property>
     </widget>
+    <widget class="QLabel" name="barcodeSizeLabel">
+     <property name="geometry">
+      <rect>
+       <x>10</x>
+       <y>190</y>
+       <width>221</width>
+       <height>17</height>
+      </rect>
+     </property>
+     <property name="font">
+      <font>
+       <weight>75</weight>
+       <bold>true</bold>
+      </font>
+     </property>
+     <property name="text">
+      <string>Barcode:</string>
+     </property>
+    </widget>
+    <widget class="QSpinBox" name="lineWidthSpinBox">
+     <property name="geometry">
+      <rect>
+       <x>250</x>
+       <y>150</y>
+       <width>61</width>
+       <height>27</height>
+      </rect>
+     </property>
+     <property name="minimum">
+      <number>1</number>
+     </property>
+     <property name="maximum">
+      <number>50</number>
+     </property>
+    </widget>
+    <widget class="QLabel" name="lineWidthLabel">
+     <property name="geometry">
+      <rect>
+       <x>10</x>
+       <y>155</y>
+       <width>231</width>
+       <height>17</height>
+      </rect>
+     </property>
+     <property name="font">
+      <font>
+       <weight>75</weight>
+       <bold>true</bold>
+      </font>
+     </property>
+     <property name="text">
+      <string>Width of line selection (pixels):</string>
+     </property>
+    </widget>
+    <widget class="QLabel" name="barWidthLabel">
+     <property name="geometry">
+      <rect>
+       <x>100</x>
+       <y>220</y>
+       <width>271</width>
+       <height>17</height>
+      </rect>
+     </property>
+     <property name="text">
+      <string>Persistence bar width (pixels)</string>
+     </property>
+    </widget>
+    <widget class="QSpinBox" name="barWidthSpinBox">
+     <property name="geometry">
+      <rect>
+       <x>30</x>
+       <y>215</y>
+       <width>61</width>
+       <height>27</height>
+      </rect>
+     </property>
+     <property name="minimum">
+      <number>1</number>
+     </property>
+     <property name="maximum">
+      <number>50</number>
+     </property>
+    </widget>
+    <widget class="QSpinBox" name="barSpacingSpinBox">
+     <property name="geometry">
+      <rect>
+       <x>30</x>
+       <y>255</y>
+       <width>61</width>
+       <height>27</height>
+      </rect>
+     </property>
+     <property name="minimum">
+      <number>1</number>
+     </property>
+     <property name="maximum">
+      <number>50</number>
+     </property>
+    </widget>
+    <widget class="QLabel" name="barSpacingLabel">
+     <property name="geometry">
+      <rect>
+       <x>100</x>
+       <y>260</y>
+       <width>271</width>
+       <height>17</height>
+      </rect>
+     </property>
+     <property name="text">
+      <string>Persistence bar spacing (pixels)</string>
+     </property>
+    </widget>
    </widget>
-   <widget class="QWidget" name="labelsTab">
+   <widget class="QWidget" name="textTab">
     <attribute name="title">
-     <string>Labels</string>
+     <string>Text</string>
     </attribute>
     <widget class="QLabel" name="axisLabelLabel">
      <property name="geometry">
@@ -577,6 +706,94 @@
        <width>251</width>
        <height>27</height>
       </rect>
+     </property>
+    </widget>
+    <widget class="QLabel" name="fontLabel">
+     <property name="geometry">
+      <rect>
+       <x>10</x>
+       <y>120</y>
+       <width>261</width>
+       <height>17</height>
+      </rect>
+     </property>
+     <property name="font">
+      <font>
+       <weight>75</weight>
+       <bold>true</bold>
+      </font>
+     </property>
+     <property name="text">
+      <string>Font</string>
+     </property>
+    </widget>
+    <widget class="QLabel" name="fontSizeLabel">
+     <property name="geometry">
+      <rect>
+       <x>30</x>
+       <y>150</y>
+       <width>101</width>
+       <height>17</height>
+      </rect>
+     </property>
+     <property name="font">
+      <font>
+       <weight>50</weight>
+       <bold>false</bold>
+      </font>
+     </property>
+     <property name="text">
+      <string>Size (points):</string>
+     </property>
+    </widget>
+    <widget class="QSpinBox" name="fontSizeSpinBox">
+     <property name="geometry">
+      <rect>
+       <x>140</x>
+       <y>145</y>
+       <width>52</width>
+       <height>27</height>
+      </rect>
+     </property>
+     <property name="minimum">
+      <number>6</number>
+     </property>
+     <property name="maximum">
+      <number>72</number>
+     </property>
+     <property name="value">
+      <number>12</number>
+     </property>
+    </widget>
+    <widget class="QLabel" name="fontSample">
+     <property name="geometry">
+      <rect>
+       <x>230</x>
+       <y>150</y>
+       <width>311</width>
+       <height>121</height>
+      </rect>
+     </property>
+     <property name="font">
+      <font>
+       <weight>50</weight>
+       <bold>false</bold>
+      </font>
+     </property>
+     <property name="autoFillBackground">
+      <bool>false</bool>
+     </property>
+     <property name="styleSheet">
+      <string notr="true">QLabel { background-color : white; color : black; }</string>
+     </property>
+     <property name="frameShape">
+      <enum>QFrame::Box</enum>
+     </property>
+     <property name="text">
+      <string>sample</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignCenter</set>
      </property>
     </widget>
    </widget>

--- a/interface/control_dot.cpp
+++ b/interface/control_dot.cpp
@@ -67,6 +67,7 @@ void ControlDot::paint(QPainter* painter, const QStyleOptionGraphicsItem* /*unus
 
 QVariant ControlDot::itemChange(GraphicsItemChange change, const QVariant& value)
 {
+    qDebug() << "Inside ControlDot::itemChange()";
     if (change == QGraphicsItem::ItemPositionChange && !update_lock) {
         QPointF mouse = value.toPointF();
         QPointF newpos(mouse);
@@ -135,6 +136,7 @@ QVariant ControlDot::itemChange(GraphicsItemChange change, const QVariant& value
         //return
         return newpos;
     }
+    qDebug() << "Finishing ControlDot::itemChange()";
     return QGraphicsItem::itemChange(change, value);
 }
 

--- a/interface/control_dot.cpp
+++ b/interface/control_dot.cpp
@@ -67,7 +67,6 @@ void ControlDot::paint(QPainter* painter, const QStyleOptionGraphicsItem* /*unus
 
 QVariant ControlDot::itemChange(GraphicsItemChange change, const QVariant& value)
 {
-    qDebug() << "Inside ControlDot::itemChange()";
     if (change == QGraphicsItem::ItemPositionChange && !update_lock) {
         QPointF mouse = value.toPointF();
         QPointF newpos(mouse);
@@ -136,7 +135,7 @@ QVariant ControlDot::itemChange(GraphicsItemChange change, const QVariant& value
         //return
         return newpos;
     }
-    qDebug() << "Finishing ControlDot::itemChange()";
+    
     return QGraphicsItem::itemChange(change, value);
 }
 

--- a/interface/control_dot.cpp
+++ b/interface/control_dot.cpp
@@ -46,7 +46,8 @@ ControlDot::ControlDot(SliceLine* line, bool left_bottom, ConfigParameters* para
 
 QRectF ControlDot::boundingRect() const
 {
-    return QRectF(-10, -10, 20, 20);
+    int radius = config_params->sliceLineWidth + 4;
+    return QRectF(-1*radius, -1*radius, 2*radius, 2*radius);
 }
 
 void ControlDot::paint(QPainter* painter, const QStyleOptionGraphicsItem* /*unused*/, QWidget* /*unused*/)

--- a/interface/persistence_bar.cpp
+++ b/interface/persistence_bar.cpp
@@ -47,14 +47,14 @@ QPainterPath PersistenceBar::shape() const
     QPainterPathStroker stroker;
     path.moveTo(0, 0);
     path.lineTo(dx, dy);
-    stroker.setWidth(10);
+    stroker.setWidth(config_params->persistenceBarWidth);
     return stroker.createStroke(path);
 }
 
 void PersistenceBar::paint(QPainter* painter, const QStyleOptionGraphicsItem* /*unused*/, QWidget* /*unused*/)
 {
     QPen pen(config_params->persistenceColor);
-    pen.setWidth(4);
+    pen.setWidth(config_params->persistenceBarWidth);
 
     if (pressed) {
         pen.setColor(config_params->persistenceHighlightColor);

--- a/interface/persistence_bar.cpp
+++ b/interface/persistence_bar.cpp
@@ -32,6 +32,7 @@ PersistenceBar::PersistenceBar(SliceDiagram* s_diagram, ConfigParameters* params
     , pressed(false)
     , secondary(false)
     , hover(false)
+    , width(params->persistenceBarWidth)
 {
     setAcceptHoverEvents(true);
 }
@@ -47,7 +48,7 @@ QPainterPath PersistenceBar::shape() const
     QPainterPathStroker stroker;
     path.moveTo(0, 0);
     path.lineTo(dx, dy);
-    stroker.setWidth(config_params->persistenceBarWidth);
+    stroker.setWidth(width);
     return stroker.createStroke(path);
 }
 
@@ -70,9 +71,16 @@ void PersistenceBar::paint(QPainter* painter, const QStyleOptionGraphicsItem* /*
 
 void PersistenceBar::set_line(double start_x, double start_y, double end_x, double end_y)
 {
+    prepareGeometryChange();
     setPos(start_x, start_y);
     dx = end_x - start_x;
     dy = end_y - start_y;
+}
+
+void PersistenceBar::set_width(int bar_width)
+{
+    prepareGeometryChange();
+    width = bar_width;
 }
 
 void PersistenceBar::select()

--- a/interface/persistence_bar.h
+++ b/interface/persistence_bar.h
@@ -39,6 +39,7 @@ public:
     void paint(QPainter* painter, const QStyleOptionGraphicsItem*, QWidget*);
 
     void set_line(double start_x, double start_y, double end_x, double end_y);
+    void set_width(int bar_width);
 
     void select();
     void select_secondary();
@@ -67,6 +68,7 @@ private:
     bool hover;
     double dx; //horizontal length of line (pixels)
     double dy; //vertical length of line (pixels)
+    int width; //width of the bar (pixels)
 };
 
 #endif // PERSISTENCE_BAR_H

--- a/interface/persistence_diagram.cpp
+++ b/interface/persistence_diagram.cpp
@@ -49,7 +49,7 @@ void PersistenceDiagram::create_diagram()
     //define pens and brushes
     QPen grayPen(QBrush(Qt::darkGray), 2, Qt::DotLine, Qt::RoundCap, Qt::RoundJoin);
     QPen thinPen(QBrush(Qt::darkGray), 1, Qt::SolidLine, Qt::RoundCap, Qt::RoundJoin);
-    QPen slicePen(QBrush(config_params->sliceLineColor), 3, Qt::SolidLine, Qt::RoundCap, Qt::RoundJoin);
+    QPen slicePen(QBrush(config_params->sliceLineColor), config_params->sliceLineWidth, Qt::SolidLine, Qt::RoundCap, Qt::RoundJoin);
     QBrush purpleBrush(QColor(config_params->persistenceColor.rgb()));
 
     //create persistence diagram structure
@@ -83,13 +83,19 @@ void PersistenceDiagram::create_diagram()
 //resizes diagram to fill the QGraphicsView; called after every window resize
 void PersistenceDiagram::resize_diagram(double slice_length, double diagram_scale)
 {
+    line_size = slice_length / sqrt(2); //divide by sqrt(2) because the line is drawn at a 45-degree angle
+    scale = diagram_scale / sqrt(2); //similarly, divide by sqrt(2)
+
+    resize_diagram();
+}
+
+//resizes diagram to fill the QGraphicsView; called after every window resize
+void PersistenceDiagram::resize_diagram()
+{
     //parameters
     int scene_padding = 10; //pixels (minimum white space between diagram objects and edge of viewing window)
     int text_padding = 4; //pixels (white space on each side of text items)
     int number_space = 30; //pixels (horizontal space reserved for counts of points above diagram)
-
-    line_size = slice_length / sqrt(2); //divide by sqrt(2) because the line is drawn at a 45-degree angle
-    scale = diagram_scale / sqrt(2); //similarly, divide by sqrt(2)
 
     //get dimensions of the QGraphicsView
     QList<QGraphicsView*> view_list = views();
@@ -380,7 +386,7 @@ void PersistenceDiagram::receive_dot_deselection()
 void PersistenceDiagram::receive_parameter_change()
 {
     //update the line highlight
-    QPen slicePen(QBrush(config_params->sliceLineColor), 3);
+    QPen slicePen(QBrush(config_params->sliceLineColor), config_params->sliceLineWidth);
     blue_line->setPen(slicePen);
 
     //update persistence dots
@@ -390,4 +396,13 @@ void PersistenceDiagram::receive_parameter_change()
     QBrush persistenceBrush(QColor(config_params->persistenceColor.rgb()));
     inf_count_text->setBrush(persistenceBrush);
     lt_inf_count_text->setBrush(persistenceBrush);
+
+    //update fonts
+    inf_text->setFont(config_params->diagramFont);
+    lt_inf_text->setFont(config_params->diagramFont);
+    inf_count_text->setFont(config_params->diagramFont);
+    lt_inf_count_text->setFont(config_params->diagramFont);
+
+    //update diagram
+    resize_diagram();
 }

--- a/interface/persistence_diagram.cpp
+++ b/interface/persistence_diagram.cpp
@@ -44,7 +44,7 @@ PersistenceDiagram::PersistenceDiagram(ConfigParameters* params, QObject* parent
 }
 
 //simply creates all objects; resize_diagram() handles positioning of objects
-void PersistenceDiagram::create_diagram(const QString& filename, int dim)
+void PersistenceDiagram::create_diagram()
 {
     //define pens and brushes
     QPen grayPen(QBrush(Qt::darkGray), 2, Qt::DotLine, Qt::RoundCap, Qt::RoundJoin);
@@ -63,25 +63,21 @@ void PersistenceDiagram::create_diagram(const QString& filename, int dim)
     //create text objects
     inf_text = addSimpleText("inf");
     inf_text->setFlag(QGraphicsItem::ItemIgnoresTransformations);
+    inf_text->setFont(config_params->diagramFont);
 
     lt_inf_text = addSimpleText("<inf");
     lt_inf_text->setFlag(QGraphicsItem::ItemIgnoresTransformations);
+    lt_inf_text->setFont(config_params->diagramFont);
 
     inf_count_text = addSimpleText("0");
     inf_count_text->setFlag(QGraphicsItem::ItemIgnoresTransformations);
     inf_count_text->setBrush(purpleBrush);
+    inf_count_text->setFont(config_params->diagramFont);
 
     lt_inf_count_text = addSimpleText("0");
     lt_inf_count_text->setFlag(QGraphicsItem::ItemIgnoresTransformations);
     lt_inf_count_text->setBrush(purpleBrush);
-
-    file_text = addSimpleText(filename);
-    file_text->setFlag(QGraphicsItem::ItemIgnoresTransformations);
-
-    std::ostringstream sdim;
-    sdim << "homology dimension: " << dim;
-    dim_text = addSimpleText(QString(sdim.str().data()));
-    dim_text->setFlag(QGraphicsItem::ItemIgnoresTransformations);
+    lt_inf_count_text->setFont(config_params->diagramFont);
 } //end create_diagram()
 
 //resizes diagram to fill the QGraphicsView; called after every window resize
@@ -139,9 +135,6 @@ void PersistenceDiagram::resize_diagram(double slice_length, double diagram_scal
 
     inf_count_text->setPos(diagram_size + text_padding, inf_text_vpos);
     lt_inf_count_text->setPos(diagram_size + text_padding, lt_inf_text_vpos);
-
-    file_text->setPos(diagram_size - file_text->boundingRect().width() - text_padding, file_text->boundingRect().height() + text_padding);
-    dim_text->setPos(diagram_size - dim_text->boundingRect().width() - text_padding, file_text->pos().y() + dim_text->boundingRect().height() + text_padding);
 
     //set scene rectangle (necessary to prevent auto-scrolling)
     double scene_rect_x = -lt_inf_text->boundingRect().width() - text_padding;

--- a/interface/persistence_diagram.h
+++ b/interface/persistence_diagram.h
@@ -39,6 +39,7 @@ public:
 
     void create_diagram(); //simply creates all objects; resize_diagram() handles positioning of objects
     void resize_diagram(double slice_length, double diagram_scale); //resizes diagram to fill the QGraphicsView; called after every window resize
+    void resize_diagram();
 
     void set_barcode(double zero, const Barcode& bc); //sets the barcode and the zero coordinate
     void draw_dots(); //creates and draws persistence dots at the correct locations, using current parameters

--- a/interface/persistence_diagram.h
+++ b/interface/persistence_diagram.h
@@ -37,7 +37,7 @@ class PersistenceDiagram : public QGraphicsScene {
 public:
     PersistenceDiagram(ConfigParameters* params, QObject* parent = 0);
 
-    void create_diagram(const QString& filename, int dim); //simply creates all objects; resize_diagram() handles positioning of objects
+    void create_diagram(); //simply creates all objects; resize_diagram() handles positioning of objects
     void resize_diagram(double slice_length, double diagram_scale); //resizes diagram to fill the QGraphicsView; called after every window resize
 
     void set_barcode(double zero, const Barcode& bc); //sets the barcode and the zero coordinate

--- a/interface/slice_diagram.cpp
+++ b/interface/slice_diagram.cpp
@@ -404,6 +404,7 @@ void SliceDiagram::redraw_dots()
 //updates the diagram after a change in configuration parameters
 void SliceDiagram::receive_parameter_change()
 {
+    qDebug() << "Inside receive_parameter_change()";
     //update colors of the xi dots (necessary because I didn't override their paint() function)
     QBrush xi0brush(config_params->xi0color);
     QBrush xi1brush(config_params->xi1color);
@@ -434,6 +435,7 @@ void SliceDiagram::receive_parameter_change()
     //update diagram
     resize_diagram();
 
+    qDebug() << "Finishing receive_parameter_change()";
 } //end update_diagram()
 
 //updates the line, in response to a change in the controls in the VisualizationWindow

--- a/interface/slice_diagram.cpp
+++ b/interface/slice_diagram.cpp
@@ -404,7 +404,6 @@ void SliceDiagram::redraw_dots()
 //updates the diagram after a change in configuration parameters
 void SliceDiagram::receive_parameter_change()
 {
-    qDebug() << "Inside receive_parameter_change()";
     //update colors of the xi dots (necessary because I didn't override their paint() function)
     QBrush xi0brush(config_params->xi0color);
     QBrush xi1brush(config_params->xi1color);
@@ -415,6 +414,14 @@ void SliceDiagram::receive_parameter_change()
         (*it)->setBrush(xi1brush);
     for (std::vector<QGraphicsEllipseItem*>::iterator it = xi2_dots.begin(); it != xi2_dots.end(); ++it)
         (*it)->setBrush(xi2brush);
+
+    //update width of persistence bars
+    //  this seems excessive, but it's necessary to call prepareGeometryChange() on each bar, and set_width() does this
+    for (unsigned i = 0; i < bars.size(); i++) {
+        for (std::list<PersistenceBar*>::iterator it = bars[i].begin(); it != bars[i].end(); ++it) {
+            (*it)->set_width(config_params->persistenceBarWidth);
+        }
+    }
 
     //update the slice line highlight
     QPen highlighter(QBrush(config_params->persistenceHighlightColor), config_params->sliceLineWidth/2);
@@ -434,8 +441,6 @@ void SliceDiagram::receive_parameter_change()
 
     //update diagram
     resize_diagram();
-
-    qDebug() << "Finishing receive_parameter_change()";
 } //end update_diagram()
 
 //updates the line, in response to a change in the controls in the VisualizationWindow
@@ -488,7 +493,6 @@ void SliceDiagram::update_line(double angle, double offset)
 //updates controls in the VisualizationWindow in response to a change in the line (also update SliceDiagram data values)
 void SliceDiagram::update_window_controls(bool from_dot)
 {
-    qDebug() << "Inside SliceDiagram::update_window_controls()";
     //update SliceDiagram data values
     line_vert = slice_line->is_vertical();
     line_slope = slice_line->get_slope() * scale_x / scale_y; //convert pixel units to data units
@@ -527,8 +531,6 @@ void SliceDiagram::update_window_controls(bool from_dot)
 
     //since the line has changed, the highlighting is no longer valid
     highlight_line->hide();
-
-    qDebug() << "Finishing SliceDiagram::update_window_controls()";
 } //end update_window_controls()
 
 //draws the barcode parallel to the slice line
@@ -563,7 +565,6 @@ void SliceDiagram::draw_barcode(Barcode const& bc, double zero_coord, bool show)
 //TODO: would it be better to move bars, instead of deleting and re-creating them?
 void SliceDiagram::update_barcode(Barcode const& bc, double zero_coord, bool show)
 {
-    qDebug() << "Inside SliceDiagram::update_barcode()";
     //remove any current selection
     primary_selected.clear();
     secondary_selected.clear();
@@ -576,11 +577,9 @@ void SliceDiagram::update_barcode(Barcode const& bc, double zero_coord, bool sho
             it->pop_back();
         }
     }
-    qDebug() << "    deleted old bars; ready to draw new bars";
 
     //draw new bars
     draw_barcode(bc, zero_coord, show);
-    qDebug() << "Finishing SliceDiagram::update_barcode()";
 }
 
 //computes an endpoint of a bar in the barcode

--- a/interface/slice_diagram.cpp
+++ b/interface/slice_diagram.cpp
@@ -102,30 +102,36 @@ void SliceDiagram::create_diagram(const QString x_text, const QString y_text, do
     s_xmin << data_xmin;
     data_xmin_text = addSimpleText(QString(s_xmin.str().data()));
     data_xmin_text->setFlag(QGraphicsItem::ItemIgnoresTransformations);
+    data_xmin_text->setFont(config_params->diagramFont);
 
     std::ostringstream s_xmax;
     s_xmax.precision(4);
     s_xmax << data_xmax;
     data_xmax_text = addSimpleText(QString(s_xmax.str().data()));
     data_xmax_text->setFlag(QGraphicsItem::ItemIgnoresTransformations);
+    data_xmax_text->setFont(config_params->diagramFont);
 
     std::ostringstream s_ymin;
     s_ymin.precision(4);
     s_ymin << data_ymin;
     data_ymin_text = addSimpleText(QString(s_ymin.str().data()));
     data_ymin_text->setFlag(QGraphicsItem::ItemIgnoresTransformations);
+    data_ymin_text->setFont(config_params->diagramFont);
 
     std::ostringstream s_ymax;
     s_ymax.precision(4);
     s_ymax << data_ymax;
     data_ymax_text = addSimpleText(QString(s_ymax.str().data()));
     data_ymax_text->setFlag(QGraphicsItem::ItemIgnoresTransformations);
+    data_ymax_text->setFont(config_params->diagramFont);
 
     x_label = addSimpleText(x_text);
     x_label->setFlag(QGraphicsItem::ItemIgnoresTransformations);
+    x_label->setFont(config_params->diagramFont);
 
     y_label = addSimpleText(y_text);
     y_label->setTransform(QTransform(0, 1, 1, 0, 0, 0));
+    y_label->setFont(config_params->diagramFont);
 
     //create rectangles for visualizing homology dimensions
     //first, find max dimension

--- a/interface/slice_diagram.cpp
+++ b/interface/slice_diagram.cpp
@@ -488,6 +488,7 @@ void SliceDiagram::update_line(double angle, double offset)
 //updates controls in the VisualizationWindow in response to a change in the line (also update SliceDiagram data values)
 void SliceDiagram::update_window_controls(bool from_dot)
 {
+    qDebug() << "Inside SliceDiagram::update_window_controls()";
     //update SliceDiagram data values
     line_vert = slice_line->is_vertical();
     line_slope = slice_line->get_slope() * scale_x / scale_y; //convert pixel units to data units
@@ -526,6 +527,8 @@ void SliceDiagram::update_window_controls(bool from_dot)
 
     //since the line has changed, the highlighting is no longer valid
     highlight_line->hide();
+
+    qDebug() << "Finishing SliceDiagram::update_window_controls()";
 } //end update_window_controls()
 
 //draws the barcode parallel to the slice line
@@ -560,6 +563,7 @@ void SliceDiagram::draw_barcode(Barcode const& bc, double zero_coord, bool show)
 //TODO: would it be better to move bars, instead of deleting and re-creating them?
 void SliceDiagram::update_barcode(Barcode const& bc, double zero_coord, bool show)
 {
+    qDebug() << "Inside SliceDiagram::update_barcode()";
     //remove any current selection
     primary_selected.clear();
     secondary_selected.clear();
@@ -572,9 +576,11 @@ void SliceDiagram::update_barcode(Barcode const& bc, double zero_coord, bool sho
             it->pop_back();
         }
     }
+    qDebug() << "    deleted old bars; ready to draw new bars";
 
     //draw new bars
     draw_barcode(bc, zero_coord, show);
+    qDebug() << "Finishing SliceDiagram::update_barcode()";
 }
 
 //computes an endpoint of a bar in the barcode

--- a/interface/slice_diagram.cpp
+++ b/interface/slice_diagram.cpp
@@ -77,7 +77,7 @@ void SliceDiagram::clear_points()
 }
 
 //NOTE: create_diagram() simply creates all objects; resize_diagram() handles positioning of objects
-void SliceDiagram::create_diagram(const QString x_text, const QString y_text, double xmin, double xmax, double ymin, double ymax, bool norm_coords, unsigned_matrix& hom_dims)
+void SliceDiagram::create_diagram(const QString& x_text, const QString& y_text, double xmin, double xmax, double ymin, double ymax, bool norm_coords, unsigned_matrix& hom_dims)
 {
     //set data-dependent parameters
     data_xmin = xmin;
@@ -402,7 +402,7 @@ void SliceDiagram::redraw_dots()
 } //end redraw_dots()
 
 //updates the diagram after a change in configuration parameters
-void SliceDiagram::receive_parameter_change(const QString& xtext, const QString& ytext)
+void SliceDiagram::receive_parameter_change()
 {
     //update colors of the xi dots (necessary because I didn't override their paint() function)
     QBrush xi0brush(config_params->xi0color);
@@ -420,8 +420,8 @@ void SliceDiagram::receive_parameter_change(const QString& xtext, const QString&
     highlight_line->setPen(highlighter);
 
     //update axis labels
-    x_label->setText(xtext);
-    y_label->setText(ytext);
+    x_label->setText(config_params->xLabel);
+    y_label->setText(config_params->yLabel);
 
     //update fonts
     data_xmin_text->setFont(config_params->diagramFont);

--- a/interface/slice_diagram.cpp
+++ b/interface/slice_diagram.cpp
@@ -284,10 +284,11 @@ void SliceDiagram::resize_diagram()
         int min_grid = (x_grid < y_grid) ? x_grid : y_grid;
 
         int auto_radius = (int)min_grid / sqrt(max_xi_value);
+        int max_radius = (int)( std::min(diagram_max_height, diagram_max_width)/20 );
         if (auto_radius < 3)
             auto_radius = 3;
-        if (auto_radius > 50)
-            auto_radius = 50;
+        if (auto_radius > max_radius)
+            auto_radius = max_radius;
 
         config_params->bettiDotRadius = auto_radius;
         config_params->persistenceDotRadius = auto_radius;

--- a/interface/slice_diagram.cpp
+++ b/interface/slice_diagram.cpp
@@ -94,7 +94,7 @@ void SliceDiagram::create_diagram(const QString x_text, const QString y_text, do
     QBrush xi1brush(config_params->xi1color);
     QBrush xi2brush(config_params->xi2color);
     QPen grayPen(Qt::gray);
-    QPen highlighter(QBrush(config_params->persistenceHighlightColor), 6);
+    QPen highlighter(QBrush(config_params->persistenceHighlightColor), config_params->sliceLineWidth/2);
 
     //draw labels
     std::ostringstream s_xmin;
@@ -286,6 +286,8 @@ void SliceDiagram::resize_diagram()
         int auto_radius = (int)min_grid / sqrt(max_xi_value);
         if (auto_radius < 3)
             auto_radius = 3;
+        if (auto_radius > 50)
+            auto_radius = 50;
 
         config_params->bettiDotRadius = auto_radius;
         config_params->persistenceDotRadius = auto_radius;
@@ -413,12 +415,20 @@ void SliceDiagram::receive_parameter_change(const QString& xtext, const QString&
         (*it)->setBrush(xi2brush);
 
     //update the slice line highlight
-    QPen highlighter(QBrush(config_params->persistenceHighlightColor), 6);
+    QPen highlighter(QBrush(config_params->persistenceHighlightColor), config_params->sliceLineWidth/2);
     highlight_line->setPen(highlighter);
 
     //update axis labels
     x_label->setText(xtext);
     y_label->setText(ytext);
+
+    //update fonts
+    data_xmin_text->setFont(config_params->diagramFont);
+    data_xmax_text->setFont(config_params->diagramFont);
+    data_ymin_text->setFont(config_params->diagramFont);
+    data_ymax_text->setFont(config_params->diagramFont);
+    x_label->setFont(config_params->diagramFont);
+    y_label->setFont(config_params->diagramFont);
 
     //update diagram
     resize_diagram();
@@ -568,7 +578,7 @@ void SliceDiagram::update_barcode(Barcode const& bc, double zero_coord, bool sho
 std::pair<double, double> SliceDiagram::compute_endpoint(double coordinate, unsigned offset)
 {
     //difference in offset between consecutive bars (pixel units)
-    int step_size = 10;
+    int step_size = config_params->persistenceBarWidth + config_params->persistenceBarSpace;
 
     //handle infinity
     if (coordinate == std::numeric_limits<double>::infinity())

--- a/interface/slice_diagram.h
+++ b/interface/slice_diagram.h
@@ -49,7 +49,7 @@ public:
     void add_point(double x_coord, double y_coord, int xi0m, int xi1m, int xi2m); //receives an xi support point, which will be drawn when create_diagram() is called
     void clear_points(); //removes all previously-created points from the diagram
 
-    void create_diagram(const QString x_text, const QString y_text, double xmin, double xmax, double ymin, double ymax, bool norm_coords, unsigned_matrix& hom_dims); //simply creates all objects; resize_diagram() handles positioning of objects
+    void create_diagram(const QString& x_text, const QString& y_text, double xmin, double xmax, double ymin, double ymax, bool norm_coords, unsigned_matrix& hom_dims); //simply creates all objects; resize_diagram() handles positioning of objects
     void enable_slice_line(); //enables the slice line and control dots
     bool is_created(); //true if the diagram has been created; false otherwise
     void resize_diagram(); //resizes diagram to fill the QGraphicsView
@@ -76,7 +76,7 @@ public:
     double get_slice_length(); //gets the length of the slice, for scaling the persistence diagram
     double get_pd_scale(); //gets the number of pixels per unit, for the persistence diagram
 
-    void receive_parameter_change(const QString& xtext, const QString& ytext); //updates the diagram after a change in configuration parameters
+    void receive_parameter_change(); //updates the diagram after a change in configuration parameters
 
 public slots:
     void receive_bar_selection(std::vector<unsigned> indexes); //highlight the specified class of bars, which has been selected externally

--- a/interface/slice_line.cpp
+++ b/interface/slice_line.cpp
@@ -178,6 +178,7 @@ void SliceLine::update_lb_endpoint(QPointF& newpos)
 //updates right-top endpoint
 void SliceLine::update_rt_endpoint(QPointF& newpos)
 {
+    qDebug() << "Inside SliceLine::update_rt_endpoint()";
     update_lock = true;
 
     //reposition the right endpoint where it should be
@@ -198,6 +199,7 @@ void SliceLine::update_rt_endpoint(QPointF& newpos)
     sdgm->update_window_controls(true);
 
     update_lock = false;
+    qDebug() << "Finishing SliceLine::update_rt_endpoint()";
 }
 
 //gets x-coordinate of right-top endpoint

--- a/interface/slice_line.cpp
+++ b/interface/slice_line.cpp
@@ -58,14 +58,14 @@ QPainterPath SliceLine::shape() const
     QPainterPathStroker stroker;
     path.moveTo(0, 0);
     path.lineTo(right_point);
-    stroker.setWidth(20);
+    stroker.setWidth(config_params->sliceLineWidth + 2);
     return stroker.createStroke(path);
 }
 
 void SliceLine::paint(QPainter* painter, const QStyleOptionGraphicsItem* /*unused*/, QWidget* /*unused*/)
 {
     QPen pen(config_params->sliceLineColor);
-    pen.setWidth(4);
+    pen.setWidth(config_params->sliceLineWidth);
 
     if (pressed) {
         pen.setColor(config_params->sliceLineHighlightColor);

--- a/interface/slice_line.cpp
+++ b/interface/slice_line.cpp
@@ -178,7 +178,6 @@ void SliceLine::update_lb_endpoint(QPointF& newpos)
 //updates right-top endpoint
 void SliceLine::update_rt_endpoint(QPointF& newpos)
 {
-    qDebug() << "Inside SliceLine::update_rt_endpoint()";
     update_lock = true;
 
     //reposition the right endpoint where it should be
@@ -199,7 +198,6 @@ void SliceLine::update_rt_endpoint(QPointF& newpos)
     sdgm->update_window_controls(true);
 
     update_lock = false;
-    qDebug() << "Finishing SliceLine::update_rt_endpoint()";
 }
 
 //gets x-coordinate of right-top endpoint

--- a/visualizationwindow.cpp
+++ b/visualizationwindow.cpp
@@ -280,6 +280,7 @@ void VisualizationWindow::on_xi2CheckBox_toggled(bool checked)
 //updates the persistence diagram and barcode after a change in the slice line
 void VisualizationWindow::update_persistence_diagram()
 {
+    qDebug() << "Inside VisualizationWindow::update_persistence_diagram()";
     if (persistence_diagram_drawn) {
         //get the barcode
         if (verbosity >= 4) {
@@ -305,6 +306,7 @@ void VisualizationWindow::update_persistence_diagram()
         p_diagram.update_diagram(slice_diagram.get_slice_length(), slice_diagram.get_pd_scale(), zero_coord, *barcode);
         slice_diagram.update_barcode(*barcode, zero_coord, ui->barcodeCheckBox->isChecked());
     }
+    qDebug() << "Finishing VisualizationWindow::update_persistence_diagram()";
 }
 
 void VisualizationWindow::set_line_parameters(double angle, double offset)

--- a/visualizationwindow.cpp
+++ b/visualizationwindow.cpp
@@ -116,6 +116,13 @@ void VisualizationWindow::start_computation()
     //start the computation in a new thread
     cthread.compute();
 
+    //update text items
+    auto shortName = QString::fromStdString(input_params.shortName);
+    this->setWindowTitle("RIVET - " + shortName);
+    ui->filenameLabel->setText( QStringLiteral("Input file: ").append(shortName) );
+    ui->homdimLabel->setText( QStringLiteral("Homology dimension: %1").arg(input_params.dim) );
+
+
 } //end start_computation()
 
 //this slot is signaled when the xi support points are ready to be drawn
@@ -169,12 +176,9 @@ void VisualizationWindow::augmented_arrangement_ready(std::shared_ptr<Arrangemen
     //TESTING: print arrangement info and verify consistency
     //    arrangement->print_stats();
     //    arrangement->test_consistency();
-    auto shortName = QString::fromStdString(input_params.shortName);
 
-    this->setWindowTitle("RIVET - " + shortName);
-
-    //inialize persistence diagram
-    p_diagram.create_diagram(shortName, input_params.dim);
+    //create persistence diagram
+    p_diagram.create_diagram();
 
     //get the barcode
     BarcodeTemplate dbc = arrangement->get_barcode_template(angle_precise, offset_precise);

--- a/visualizationwindow.cpp
+++ b/visualizationwindow.cpp
@@ -280,7 +280,6 @@ void VisualizationWindow::on_xi2CheckBox_toggled(bool checked)
 //updates the persistence diagram and barcode after a change in the slice line
 void VisualizationWindow::update_persistence_diagram()
 {
-    qDebug() << "Inside VisualizationWindow::update_persistence_diagram()";
     if (persistence_diagram_drawn) {
         //get the barcode
         if (verbosity >= 4) {
@@ -306,7 +305,6 @@ void VisualizationWindow::update_persistence_diagram()
         p_diagram.update_diagram(slice_diagram.get_slice_length(), slice_diagram.get_pd_scale(), zero_coord, *barcode);
         slice_diagram.update_barcode(*barcode, zero_coord, ui->barcodeCheckBox->isChecked());
     }
-    qDebug() << "Finishing VisualizationWindow::update_persistence_diagram()";
 }
 
 void VisualizationWindow::set_line_parameters(double angle, double offset)

--- a/visualizationwindow.cpp
+++ b/visualizationwindow.cpp
@@ -141,10 +141,12 @@ void VisualizationWindow::paint_template_points(std::shared_ptr<TemplatePointsMe
         slice_diagram.add_point(grades.x[point.x], grades.y[point.y], point.zero, point.one, point.two);
 
     //create the SliceDiagram
+    config_params.xLabel = QString::fromStdString(template_points->x_label);
+    config_params.yLabel = QString::fromStdString(template_points->y_label);
     if (!slice_diagram.is_created()) {
         slice_diagram.create_diagram(
-            QString::fromStdString(template_points->x_label),
-            QString::fromStdString(template_points->y_label),
+            config_params.xLabel,
+            config_params.yLabel,
             grades.x.front(), grades.x.back(),
             grades.y.front(), grades.y.back(),
             ui->normCoordCheckBox->isChecked(), template_points->homology_dimensions);
@@ -378,8 +380,7 @@ void VisualizationWindow::on_actionConfigure_triggered()
     configBox->exec();
 
     if (line_selection_ready) {
-        slice_diagram.receive_parameter_change(QString::fromStdString(template_points->x_label),
-            QString::fromStdString(template_points->y_label));
+        slice_diagram.receive_parameter_change();
 
         if (persistence_diagram_drawn)
             p_diagram.receive_parameter_change();

--- a/visualizationwindow.h
+++ b/visualizationwindow.h
@@ -130,7 +130,6 @@ private:
     double project(TemplatePoint& pt, double angle, double offset, std::vector<double> x_grades, std::vector<double> y_grades);
 
     //computes the projection of the lower-left corner of the line-selection window onto the specified line
-    // TESTING AS REPLACEMENT FOR SliceDiagram::get_zero()
     double project_zero(double angle, double offset, double x_0, double y_0);
 
     //other items

--- a/visualizationwindow.ui
+++ b/visualizationwindow.ui
@@ -376,32 +376,32 @@
        <widget class="QGraphicsView" name="pdView"/>
       </item>
       <item row="2" column="1">
-       <layout class="QHBoxLayout" name="horizontalLayout_pd_controls">
+       <layout class="QVBoxLayout" name="verticalLayout_for_text">
         <item>
-         <spacer name="horizontalSpacer_4">
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
+         <widget class="QLabel" name="filenameLabel">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Ignored" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
           </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>40</width>
-            <height>20</height>
-           </size>
+          <property name="text">
+           <string>Input file:</string>
           </property>
-         </spacer>
+          <property name="alignment">
+           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+          </property>
+         </widget>
         </item>
         <item>
-         <spacer name="horizontalSpacer_5">
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
+         <widget class="QLabel" name="homdimLabel">
+          <property name="text">
+           <string>Homology dimension:</string>
           </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>40</width>
-            <height>20</height>
-           </size>
+          <property name="alignment">
+           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
           </property>
-         </spacer>
+         </widget>
         </item>
        </layout>
       </item>


### PR DESCRIPTION
I have added options to the Configure box that let the user adjust the sizes of fonts, the slice line, and the persistence bars. I also edited the automatic dot sizing so that the dots are (hopefully) not too big.