### PR TITLE
Betti output fix

### DIFF
--- a/console.cpp
+++ b/console.cpp
@@ -125,17 +125,11 @@ void print_dims(TemplatePointsMessage const& message, std::ostream& ostream)
     auto data = message.homology_dimensions.data();
     ostream << "Dimensions > 0:" << std::endl;
 
-    ostream << "shape: " << shape[0] << ", " << shape[1] << std::endl;
-
-    for(unsigned i=0; i<shape[0]*shape[1]; i++)
-        ostream << data[i] << " ";
-    ostream << std::endl;
-
     for (unsigned long col = 0; col < shape[0]; col++) {
         for (unsigned long row = 0; row < shape[1]; row++) {
             unsigned dim = data[col * shape[1] + row];
             if (dim > 0) {
-                ostream << "(" << col << ", " << row << ", " << dim << ") -- position " << (col * shape[1] + row) << std::endl;
+                ostream << "(" << col << ", " << row << ", " << dim << ")" << std::endl;
             }
         }
         ostream << std::endl;

--- a/console.cpp
+++ b/console.cpp
@@ -125,11 +125,17 @@ void print_dims(TemplatePointsMessage const& message, std::ostream& ostream)
     auto data = message.homology_dimensions.data();
     ostream << "Dimensions > 0:" << std::endl;
 
-    for (unsigned long row = 0; row < shape[0]; row++) {
-        for (unsigned long col = 0; col < shape[1]; col++) {
-            unsigned dim = data[row * shape[0] + col];
+    ostream << "shape: " << shape[0] << ", " << shape[1] << std::endl;
+
+    for(unsigned i=0; i<shape[0]*shape[1]; i++)
+        ostream << data[i] << " ";
+    ostream << std::endl;
+
+    for (unsigned long col = 0; col < shape[0]; col++) {
+        for (unsigned long row = 0; row < shape[1]; row++) {
+            unsigned dim = data[col * shape[1] + row];
             if (dim > 0) {
-                ostream << "(" << col << ", " << row << ", " << dim << ")" << std::endl;
+                ostream << "(" << col << ", " << row << ", " << dim << ") -- position " << (col * shape[1] + row) << std::endl;
             }
         }
         ostream << std::endl;


### PR DESCRIPTION
I noticed this week that the --betti flag gives incorrect output when the number of x-bins differs from the number of y-bins. I have corrected the output in this pull request. This also makes the output appear in lex order, which (I think) is what we want.