### PR TITLE
Fix a big memory leak, support a better binary format, and steps toward C++ and C API's

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ ui_progressdialog.h
 ui_visualizationwindow.h
 build
 cmake-build-*
+msgpack

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,7 @@ externalproject_add(
         msgpack_project
         PREFIX msgpack
         GIT_REPOSITORY https://github.com/msgpack/msgpack-c
-        GIT_TAG master
+        GIT_TAG 83a4b89818d4ed3b84d69cbf36e782c641ffab53
         CMAKE_ARGS -D CMAKE_CXX_STANDARD=11 -D CMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
         INSTALL_COMMAND ""
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,6 +35,38 @@ include_directories("${PROJECT_SOURCE_DIR}" "${PROJECT_SOURCE_DIR}/include" ${Bo
        "${CMAKE_CURRENT_BINARY_DIR}/msgpack/src/msgpack_project/include" )
 
 add_definitions(-DMSGPACK_USE_BOOST)
+include_directories("${PROJECT_SOURCE_DIR}" "${PROJECT_SOURCE_DIR}/include" ${Boost_INCLUDE_DIR} "${CMAKE_CURRENT_BINARY_DIR}/docopt/src/docopt_project")
+
+add_library(rivet
+        computation.cpp
+        interface/progress.cpp
+        interface/file_writer.cpp
+        interface/file_input_reader.cpp
+        interface/input_manager.cpp
+        dcel/barcode.cpp
+        dcel/arrangement.cpp
+        dcel/arrangement_builder.cpp
+        dcel/anchor.cpp
+        dcel/barcode_template.cpp
+        dcel/dcel.cpp
+        dcel/arrangement_message.cpp
+        math/map_matrix.cpp
+        math/multi_betti.cpp
+        math/simplex_tree.cpp
+        math/st_node.cpp
+        math/template_point.cpp
+        math/template_points_matrix.cpp
+        math/index_matrix.cpp
+        math/persistence_updater.cpp
+        numerics.cpp
+        timer.cpp
+        debug.cpp
+        dcel/grades.cpp
+        dcel/grades.h
+        math/bool_array.cpp
+        math/bool_array.h
+        interface/c_api.cpp
+        interface/c_api.h api.h api.cpp)
 
 add_executable (rivet_console
         console.cpp
@@ -61,7 +93,11 @@ add_executable (rivet_console
         numerics.cpp
         timer.cpp
         debug.cpp
-        dcel/grades.cpp dcel/grades.h math/bool_array.cpp math/bool_array.h)
+        dcel/grades.cpp
+        dcel/grades.h
+        math/bool_array.cpp
+        math/bool_array.h
+        api.cpp)
 
 add_dependencies(rivet_console docopt_project)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,6 +68,7 @@ add_library(rivet
         interface/c_api.h api.h api.cpp)
 
 add_dependencies(rivet msgpack_project)
+target_link_libraries(rivet ${Boost_LIBRARIES})
 
 add_executable (rivet_console
         console.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ set (CMAKE_CXX_STANDARD 14)
 if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE Release)
 endif()
-set(CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS} "-ftemplate-depth=1024 -Wall -Wextra -pedantic")
+set(CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS} "-ftemplate-depth=1024 -Wall -Wextra -pedantic -fPIC")
 
 include(ExternalProject)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,13 +17,24 @@ externalproject_add(
   INSTALL_COMMAND ""
   )
 
+externalproject_add(
+        msgpack_project
+        PREFIX msgpack
+        GIT_REPOSITORY https://github.com/msgpack/msgpack-c
+        GIT_TAG master
+        CMAKE_ARGS -D CMAKE_CXX_STANDARD=11 -D CMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
+        INSTALL_COMMAND ""
+)
 
 find_package(Boost "1.60" COMPONENTS serialization system)
 
 #note this must come before add_executable or it will be ignored
 link_directories(${CMAKE_CURRENT_BINARY_DIR}/docopt/src/docopt_project-build)
 
-include_directories("${PROJECT_SOURCE_DIR}" "${PROJECT_SOURCE_DIR}/include" ${Boost_INCLUDE_DIR} "${CMAKE_CURRENT_BINARY_DIR}/docopt/src/docopt_project")
+include_directories("${PROJECT_SOURCE_DIR}" "${PROJECT_SOURCE_DIR}/include" ${Boost_INCLUDE_DIR} "${CMAKE_CURRENT_BINARY_DIR}/docopt/src/docopt_project"
+       "${CMAKE_CURRENT_BINARY_DIR}/msgpack/src/msgpack_project/include" )
+
+add_definitions(-DMSGPACK_USE_BOOST)
 
 add_executable (rivet_console
         console.cpp
@@ -71,6 +82,7 @@ add_executable(unit_tests
         dcel/barcode.cpp
         dcel/barcode_template.cpp
         dcel/dcel.cpp
+        dcel/serialization.h
         math/map_matrix.cpp
         math/multi_betti.cpp
         math/simplex_tree.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,7 +35,6 @@ include_directories("${PROJECT_SOURCE_DIR}" "${PROJECT_SOURCE_DIR}/include" ${Bo
        "${CMAKE_CURRENT_BINARY_DIR}/msgpack/src/msgpack_project/include" )
 
 add_definitions(-DMSGPACK_USE_BOOST)
-include_directories("${PROJECT_SOURCE_DIR}" "${PROJECT_SOURCE_DIR}/include" ${Boost_INCLUDE_DIR} "${CMAKE_CURRENT_BINARY_DIR}/docopt/src/docopt_project")
 
 add_library(rivet
         computation.cpp
@@ -68,6 +67,8 @@ add_library(rivet
         interface/c_api.cpp
         interface/c_api.h api.h api.cpp)
 
+add_dependencies(rivet msgpack_project)
+
 add_executable (rivet_console
         console.cpp
         computation.cpp
@@ -99,7 +100,7 @@ add_executable (rivet_console
         math/bool_array.h
         api.cpp)
 
-add_dependencies(rivet_console docopt_project)
+add_dependencies(rivet_console docopt_project msgpack_project)
 
 target_link_libraries(rivet_console ${CMAKE_CURRENT_BINARY_DIR}/docopt/src/docopt_project-build/libdocopt_s.a ${Boost_LIBRARIES})
 # TODO: Make this file run the qmake build as well, and copy the rivet_console into the same dir where the viewer is built
@@ -132,7 +133,8 @@ add_executable(unit_tests
         debug.cpp
         test/unit_tests.cpp dcel/grades.cpp dcel/grades.h math/bool_array.cpp math/bool_array.h)
 
+add_dependencies(unit_tests msgpack_project)
 
 include_directories("${PROJECT_SOURCE_DIR}" "${PROJECT_SOURCE_DIR}/include" ${Boost_INCLUDE_DIR} ${PROJECT_SOURCE_DIR}/test)
 
-target_link_libraries(unit_tests ${Boost_LIBRARIES})
+target_link_libraries(unit_tests ${Boost_LIBRARIES} )

--- a/RIVET.pro
+++ b/RIVET.pro
@@ -18,6 +18,7 @@ TARGET = RIVET
 TEMPLATE = app
 
 QMAKE_LIBDIR += /usr/local/lib #TODO: figure out how to generalize
+INCLUDEPATH += $$PWD/build/msgpack/src/msgpack_project/include
 LIBS        += -lboost_serialization
 
 SOURCES	+= main.cpp                         \

--- a/api.cpp
+++ b/api.cpp
@@ -45,10 +45,10 @@ std::unique_ptr<ComputationResult> from_istream(std::istream &file) {
 std::unique_ptr<ComputationResult> from_messages(
         const TemplatePointsMessage &templatePointsMessage,
         const ArrangementMessage &arrangementMessage) {
-    std::__1::unique_ptr<ComputationResult> result(new ComputationResult);
+    std::unique_ptr<ComputationResult> result(new ComputationResult);
     result->arrangement.reset(new Arrangement);
     *(result->arrangement) = arrangementMessage.to_arrangement();
-    std::__1::vector<size_t> ex;
+    std::vector<size_t> ex;
     const size_t* shape = templatePointsMessage.homology_dimensions.shape();
     ex.assign(shape, shape + templatePointsMessage.homology_dimensions.num_dimensions());
     result->homology_dimensions.resize(ex);

--- a/api.cpp
+++ b/api.cpp
@@ -1,0 +1,73 @@
+//
+// Created by Bryn Keller on 11/16/17.
+//
+#include <boost/archive/binary_iarchive.hpp>
+#include "dcel/serialization.h"
+#include "api.h"
+
+std::unique_ptr<ComputationResult> from_istream(std::istream &file) {
+    std::string type;
+    std::getline(file, type);
+    InputParameters params;
+    TemplatePointsMessage templatePointsMessage;
+    ArrangementMessage arrangementMessage;
+    if (type == "RIVET_1") {
+        boost::archive::binary_iarchive archive(file);
+        archive >> params;
+        archive >> templatePointsMessage;
+        archive >> arrangementMessage;
+    } else if (type == "RIVET_msgpack") {
+        std::string buffer((std::istreambuf_iterator<char>(file)),
+                           std::istreambuf_iterator<char>());
+
+        msgpack::unpacker pac;
+        pac.reserve_buffer( buffer.size() );
+        std::copy( buffer.begin(), buffer.end(), pac.buffer() );
+        pac.buffer_consumed( buffer.size() );
+
+        msgpack::object_handle oh;
+        pac.next(oh);
+        auto m1 = oh.get();
+        m1.convert(params);
+        pac.next(oh);
+        auto m2 = oh.get();
+        m2.convert(templatePointsMessage);
+        pac.next(oh);
+        auto m3 = oh.get();
+        m3.convert(arrangementMessage);
+
+    } else {
+        throw std::runtime_error("Expected a precomputed RIVET file");
+    }
+    return from_messages(templatePointsMessage, arrangementMessage);
+}
+
+std::unique_ptr<ComputationResult> from_messages(
+        const TemplatePointsMessage &templatePointsMessage,
+        const ArrangementMessage &arrangementMessage) {
+    std::__1::unique_ptr<ComputationResult> result(new ComputationResult);
+    result->arrangement.reset(new Arrangement);
+    *(result->arrangement) = arrangementMessage.to_arrangement();
+    std::__1::vector<size_t> ex;
+    const size_t* shape = templatePointsMessage.homology_dimensions.shape();
+    ex.assign(shape, shape + templatePointsMessage.homology_dimensions.num_dimensions());
+    result->homology_dimensions.resize(ex);
+    result->homology_dimensions = templatePointsMessage.homology_dimensions;
+    result->template_points = templatePointsMessage.template_points;
+    return result;
+}
+
+std::vector<std::unique_ptr<Barcode>> query_barcodes(const ComputationResult &computation,
+                                    const std::vector<std::pair<double, double>> &offset_slopes) {
+
+    Grades grades(computation.arrangement->x_exact, computation.arrangement->y_exact);
+    std::vector<std::unique_ptr<Barcode>> result;
+
+    for (auto query : offset_slopes) {
+        auto angle = query.first;
+        auto offset = query.second;
+        auto templ = computation.arrangement->get_barcode_template(angle, offset);
+        result.push_back(templ.rescale(angle, offset, computation.template_points, grades));
+    }
+    return result;
+}

--- a/api.cpp
+++ b/api.cpp
@@ -61,7 +61,7 @@ std::unique_ptr<ComputationResult> from_messages(
 //    std::cout << "from_messages" << std::endl;
     std::unique_ptr<ComputationResult> result(new ComputationResult);
     result->arrangement.reset(arrangementMessage.to_arrangement());
-    result->arrangement->test_consistency();
+    //result->arrangement->test_consistency();
     std::vector<size_t> ex;
     const size_t* shape = templatePointsMessage.homology_dimensions.shape();
     ex.assign(shape, shape + templatePointsMessage.homology_dimensions.num_dimensions());

--- a/api.cpp
+++ b/api.cpp
@@ -71,3 +71,17 @@ std::vector<std::unique_ptr<Barcode>> query_barcodes(const ComputationResult &co
     }
     return result;
 }
+
+Bounds compute_bounds(const ComputationResult &computation_result) {
+    const auto grades = Grades(computation_result.arrangement->x_exact, computation_result.arrangement->y_exact);
+    const auto x_low = grades.x.front();
+    const auto y_low = grades.y.front();
+    const auto x_high = grades.x.back();
+    const auto y_high = grades.y.back();
+    return Bounds {
+            x_low,
+            y_low,
+            x_high,
+            y_high
+    };
+}

--- a/api.cpp
+++ b/api.cpp
@@ -60,8 +60,8 @@ std::unique_ptr<ComputationResult> from_messages(
         const ArrangementMessage &arrangementMessage) {
 //    std::cout << "from_messages" << std::endl;
     std::unique_ptr<ComputationResult> result(new ComputationResult);
-    result->arrangement.reset(new Arrangement);
-    *(result->arrangement) = arrangementMessage.to_arrangement();
+    result->arrangement.reset(arrangementMessage.to_arrangement());
+    result->arrangement->test_consistency();
     std::vector<size_t> ex;
     const size_t* shape = templatePointsMessage.homology_dimensions.shape();
     ex.assign(shape, shape + templatePointsMessage.homology_dimensions.num_dimensions());

--- a/api.cpp
+++ b/api.cpp
@@ -5,6 +5,13 @@
 #include "dcel/serialization.h"
 #include "api.h"
 
+//class break_stream: public std::streambuf {
+//protected:
+//    int overflow(int __c) override {
+//        throw std::runtime_error("no!");
+//        //return basic_streambuf::overflow(__c);
+//    }
+//};
 std::unique_ptr<ComputationResult> from_istream(std::istream &file) {
     std::string type;
     std::getline(file, type);
@@ -28,12 +35,18 @@ std::unique_ptr<ComputationResult> from_istream(std::istream &file) {
         msgpack::object_handle oh;
         pac.next(oh);
         auto m1 = oh.get();
+//        std::cout << "params" << std::endl;
         m1.convert(params);
         pac.next(oh);
         auto m2 = oh.get();
+//        std::cout << "points" << std::endl;
+//        break_stream stream;
+//        std::cout.rdbuf(&stream);
+//        std::cerr.rdbuf(&stream);
         m2.convert(templatePointsMessage);
         pac.next(oh);
         auto m3 = oh.get();
+//        std::cout << "arrangement message" << std::endl;
         m3.convert(arrangementMessage);
 
     } else {
@@ -45,6 +58,7 @@ std::unique_ptr<ComputationResult> from_istream(std::istream &file) {
 std::unique_ptr<ComputationResult> from_messages(
         const TemplatePointsMessage &templatePointsMessage,
         const ArrangementMessage &arrangementMessage) {
+//    std::cout << "from_messages" << std::endl;
     std::unique_ptr<ComputationResult> result(new ComputationResult);
     result->arrangement.reset(new Arrangement);
     *(result->arrangement) = arrangementMessage.to_arrangement();

--- a/api.h
+++ b/api.h
@@ -1,0 +1,30 @@
+//
+// Created by Bryn Keller on 11/16/17.
+//
+
+#ifndef RIVET_CONSOLE_API_H
+#define RIVET_CONSOLE_API_H
+
+#include "dcel/anchor.h"
+#include "dcel/arrangement.h"
+#include "dcel/barcode_template.h"
+#include "dcel/dcel.h"
+#include "type_tag.h"
+#include <boost/optional.hpp>
+#include <boost/serialization/split_member.hpp>
+#include <msgpack.hpp>
+#include "dcel/msgpack_adapters.h"
+#include "computation.h"
+#include "dcel/dcel.h"
+#include "dcel/arrangement_message.h"
+#include <memory>
+
+std::unique_ptr<ComputationResult> from_messages(
+        const TemplatePointsMessage &templatePointsMessage,
+        const ArrangementMessage &arrangementMessage);
+
+std::vector<std::unique_ptr<Barcode>> query_barcodes(const ComputationResult &computation,
+                                                     const std::vector<std::pair<double, double>> &offset_slopes);
+
+std::unique_ptr<ComputationResult> from_istream(std::istream &file);
+#endif //RIVET_CONSOLE_API_H

--- a/api.h
+++ b/api.h
@@ -27,4 +27,15 @@ std::vector<std::unique_ptr<Barcode>> query_barcodes(const ComputationResult &co
                                                      const std::vector<std::pair<double, double>> &offset_slopes);
 
 std::unique_ptr<ComputationResult> from_istream(std::istream &file);
+
+
+struct Bounds {
+    double x_low;
+    double y_low;
+    double x_high;
+    double y_high;
+};
+
+Bounds compute_bounds(const ComputationResult &computation_result);
+
 #endif //RIVET_CONSOLE_API_H

--- a/console.cpp
+++ b/console.cpp
@@ -52,8 +52,8 @@ static const char USAGE[] =
       rivet_console <input_file> --identify
       rivet_console <input_file> --betti [-H <dimension>] [-V <verbosity>] [-x <xbins>] [-y <ybins>]
       rivet_console <input_file> <output_file> --betti [-H <dimension>] [-V <verbosity>] [-x <xbins>] [-y <ybins>]
-      rivet_console <precomputed_file> --bounds
-      rivet_console <precomputed_file> --barcodes <line_file>
+      rivet_console <precomputed_file> --bounds [-V <verbosity>]
+      rivet_console <precomputed_file> --barcodes <line_file> [-V <verbosity>]
       rivet_console <input_file> <output_file> [-H <dimension>] [-V <verbosity>] [-x <xbins>] [-y <ybins>] [-f <format>] [--binary]
 
     Options:
@@ -343,8 +343,9 @@ int main(int argc, char* argv[])
         if (!(*arrangement_message == test)) {
             throw std::runtime_error("Original and deserialized don't match!");
         }
-        Arrangement reconstituted = arrangement_message->to_arrangement();
-        ArrangementMessage round_trip(reconstituted);
+        Arrangement *reconstituted = arrangement_message->to_arrangement();
+        reconstituted->test_consistency();
+        ArrangementMessage round_trip(*reconstituted);
         if (!(round_trip == *arrangement_message)) {
             throw std::runtime_error("Original and reconstituted don't match!");
         }

--- a/console.cpp
+++ b/console.cpp
@@ -327,28 +327,28 @@ int main(int argc, char* argv[])
         //of the run. This message just announces the absolute path of the file.
         //The viewer should capture the file name from the stdout stream, and
         //then wait for the console program to finish before attempting to read the file.
-        std::stringstream ss(std::ios_base::binary | std::ios_base::out | std::ios_base::in);
-        {
-            boost::archive::binary_oarchive archive(ss);
-            archive << *arrangement_message;
-        }
-        std::clog << "Testing deserialization locally..." << std::endl;
-        std::string original = ss.str();
-        ArrangementMessage test;
-        {
-            boost::archive::binary_iarchive inarch(ss);
-            inarch >> test;
-            std::clog << "Deserialized!";
-        }
-        if (!(*arrangement_message == test)) {
-            throw std::runtime_error("Original and deserialized don't match!");
-        }
-        Arrangement *reconstituted = arrangement_message->to_arrangement();
-        reconstituted->test_consistency();
-        ArrangementMessage round_trip(*reconstituted);
-        if (!(round_trip == *arrangement_message)) {
-            throw std::runtime_error("Original and reconstituted don't match!");
-        }
+//        std::stringstream ss(std::ios_base::binary | std::ios_base::out | std::ios_base::in);
+//        {
+//            boost::archive::binary_oarchive archive(ss);
+//            archive << *arrangement_message;
+//        }
+//        std::clog << "Testing deserialization locally..." << std::endl;
+//        std::string original = ss.str();
+//        ArrangementMessage test;
+//        {
+//            boost::archive::binary_iarchive inarch(ss);
+//            inarch >> test;
+//            std::clog << "Deserialized!";
+//        }
+//        if (!(*arrangement_message == test)) {
+//            throw std::runtime_error("Original and deserialized don't match!");
+//        }
+//        Arrangement *reconstituted = arrangement_message->to_arrangement();
+//        //reconstituted->test_consistency();
+//        ArrangementMessage round_trip(*reconstituted);
+//        if (!(round_trip == *arrangement_message)) {
+//            throw std::runtime_error("Original and reconstituted don't match!");
+//        }
         if (binary) {
             std::cout << "ARRANGEMENT: " << params.outputFile << std::endl;
         } else if (verbosity > 0) {

--- a/console.cpp
+++ b/console.cpp
@@ -106,7 +106,6 @@ unsigned int get_uint_or_die(std::map<std::string, docopt::value>& args, const s
     }
 }
 
-//TODO: this doesn't really belong here, look for a better place.
 void write_boost_file(InputParameters const& params, TemplatePointsMessage const& message, ArrangementMessage const& arrangement)
 {
     std::ofstream file(params.outputFile, std::ios::binary);
@@ -116,6 +115,19 @@ void write_boost_file(InputParameters const& params, TemplatePointsMessage const
     file << "RIVET_1\n";
     boost::archive::binary_oarchive oarchive(file);
     oarchive& params& message& arrangement;
+    file.flush();
+}
+
+void write_msgpack_file(InputParameters const& params, TemplatePointsMessage const& message, ArrangementMessage const& arrangement)
+{
+    std::ofstream file(params.outputFile, std::ios::binary);
+    if (!file.is_open()) {
+        throw std::runtime_error("Could not open " + params.outputFile + " for writing.");
+    }
+    file << "RIVET_msgpack\n";
+    msgpack::pack(file, params);
+    msgpack::pack(file, message);
+    msgpack::pack(file, arrangement);
     file.flush();
 }
 
@@ -484,6 +496,8 @@ int main(int argc, char* argv[])
                 fw.write_augmented_arrangement(file);
             } else if (params.outputFormat == "R1") {
                 write_boost_file(params, *points_message, *arrangement_message);
+            } else if (params.outputFormat == "msgpack") {
+                write_msgpack_file(params, *points_message, *arrangement_message);
             } else {
                 throw std::runtime_error("Unsupported output format: " + params.outputFormat);
             }

--- a/console.cpp
+++ b/console.cpp
@@ -174,13 +174,9 @@ void print_betti(TemplatePointsMessage const& message, std::ostream& ostream)
 }
 
 void process_bounds(const ComputationResult &computation_result) {
-    const auto grades = Grades(computation_result.arrangement->x_exact, computation_result.arrangement->y_exact);
-    const auto x_low = grades.x.front();
-    const auto y_low = grades.y.front();
-    const auto x_high = grades.x.back();
-    const auto y_high = grades.y.back();
-    std::cout << "low: " << x_low << ", " << y_low << std::endl;
-    std::cout << "high: " << x_high << ", " << y_high << std::endl;
+    auto bounds = compute_bounds(computation_result);
+    std::cout << "low: " << bounds.x_low << ", " << bounds.y_low << std::endl;
+    std::cout << "high: " << bounds.x_high << ", " << bounds.y_high << std::endl;
 }
 
 void process_barcode_queries(std::string query_file_name, const ComputationResult& computation_result)

--- a/console.cpp
+++ b/console.cpp
@@ -327,27 +327,27 @@ int main(int argc, char* argv[])
         //of the run. This message just announces the absolute path of the file.
         //The viewer should capture the file name from the stdout stream, and
         //then wait for the console program to finish before attempting to read the file.
-//        std::stringstream ss(std::ios_base::binary | std::ios_base::out | std::ios_base::in);
-//        {
-//            boost::archive::binary_oarchive archive(ss);
-//            archive << *arrangement_message;
-//        }
-//        std::clog << "Testing deserialization locally..." << std::endl;
-//        std::string original = ss.str();
-//        ArrangementMessage test;
-//        {
-//            boost::archive::binary_iarchive inarch(ss);
-//            inarch >> test;
-//            std::clog << "Deserialized!";
-//        }
-//        if (!(*arrangement_message == test)) {
-//            throw std::runtime_error("Original and deserialized don't match!");
-//        }
-//        Arrangement reconstituted = arrangement_message->to_arrangement();
-//        ArrangementMessage round_trip(reconstituted);
-//        if (!(round_trip == *arrangement_message)) {
-//            throw std::runtime_error("Original and reconstituted don't match!");
-//        }
+        std::stringstream ss(std::ios_base::binary | std::ios_base::out | std::ios_base::in);
+        {
+            boost::archive::binary_oarchive archive(ss);
+            archive << *arrangement_message;
+        }
+        std::clog << "Testing deserialization locally..." << std::endl;
+        std::string original = ss.str();
+        ArrangementMessage test;
+        {
+            boost::archive::binary_iarchive inarch(ss);
+            inarch >> test;
+            std::clog << "Deserialized!";
+        }
+        if (!(*arrangement_message == test)) {
+            throw std::runtime_error("Original and deserialized don't match!");
+        }
+        Arrangement reconstituted = arrangement_message->to_arrangement();
+        ArrangementMessage round_trip(reconstituted);
+        if (!(round_trip == *arrangement_message)) {
+            throw std::runtime_error("Original and reconstituted don't match!");
+        }
         if (binary) {
             std::cout << "ARRANGEMENT: " << params.outputFile << std::endl;
         } else if (verbosity > 0) {

--- a/dataselectdialog.cpp
+++ b/dataselectdialog.cpp
@@ -21,6 +21,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "dataselectdialog.h"
 #include "ui_dataselectdialog.h"
 
+#include "api.h"
 #include "interface/console_interaction.h"
 #include "interface/file_input_reader.h"
 #include "interface/input_parameters.h"

--- a/dcel/anchor.cpp
+++ b/dcel/anchor.cpp
@@ -22,7 +22,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "math/template_points_matrix.h"
 #include <ostream>
 
-Anchor::Anchor(std::shared_ptr<TemplatePointsMatrixEntry> e)
+Anchor::Anchor(TemplatePointsMatrixEntry* e)
     : x_coord(e->x)
     , y_coord(e->y)
     , entry(e)
@@ -77,12 +77,12 @@ unsigned Anchor::get_y() const
     return y_coord;
 }
 
-void Anchor::set_line(std::shared_ptr<Halfedge> e)
+void Anchor::set_line(Halfedge* e)
 {
     dual_line = e;
 }
 
-std::shared_ptr<Halfedge> Anchor::get_line() const
+Halfedge* Anchor::get_line() const
 {
     return dual_line;
 }
@@ -107,7 +107,7 @@ void Anchor::toggle()
     above_line = !above_line;
 }
 
-std::shared_ptr<TemplatePointsMatrixEntry> Anchor::get_entry()
+TemplatePointsMatrixEntry* Anchor::get_entry()
 {
     return entry;
 }

--- a/dcel/anchor.h
+++ b/dcel/anchor.h
@@ -35,7 +35,7 @@ struct TemplatePointsMatrixEntry;
 
 class Anchor {
 public:
-    Anchor(std::shared_ptr<TemplatePointsMatrixEntry> e); //default constructor
+    Anchor(TemplatePointsMatrixEntry* e); //default constructor
     Anchor(unsigned x, unsigned y); //constructor, requires only x- and y-coordinates
     Anchor(); //For serialization
 
@@ -46,8 +46,8 @@ public:
     unsigned get_x() const; //get the discrete x-coordinate
     unsigned get_y() const; //get the discrete y-coordinate
 
-    void set_line(std::shared_ptr<Halfedge> e); //set the pointer to the line corresponding to this Anchor in the arrangement
-    std::shared_ptr<Halfedge> get_line() const; //get the pointer to the line corresponding to this Anchor in the arrangement
+    void set_line(Halfedge* e); //set the pointer to the line corresponding to this Anchor in the arrangement
+    Halfedge* get_line() const; //get the pointer to the line corresponding to this Anchor in the arrangement
 
     void set_position(unsigned p); //sets the relative position of the Anchor line at the sweep line, used for Bentley-Ottmann DCEL construction algorithm
     unsigned get_position() const; //gets the relative position of the Anchor line at the sweep line, used for Bentley-Ottmann DCEL construction algorithm
@@ -55,7 +55,7 @@ public:
     bool is_above(); //returns true iff this Anchor is above the current slice line, used for the vineyard-update process of storing persistence data in cells of the arrangement
     void toggle(); //toggles above/below state of this Anchor; called whever the slice line crosses this Anchor in the vineyard-update process of storing persistence data
 
-    std::shared_ptr<TemplatePointsMatrixEntry> get_entry(); //accessor
+    TemplatePointsMatrixEntry* get_entry(); //accessor
 
     void set_weight(unsigned long w); //sets the estimate of the cost of updating the RU-decomposition when crossing this anchor
     unsigned long get_weight(); //returns estimate of the cost of updating the RU-decomposition when crossing this anchor
@@ -67,9 +67,9 @@ private:
     unsigned x_coord; //discrete x-coordinate
     unsigned y_coord; //discrete y-coordinate
 
-    std::shared_ptr<TemplatePointsMatrixEntry> entry; //TemplatePointsMatrixEntry at the position of this anchor
+    TemplatePointsMatrixEntry* entry; //TemplatePointsMatrixEntry at the position of this anchor
 
-    std::shared_ptr<Halfedge> dual_line; //pointer to left-most halfedge corresponding to this Anchor in the arrangement
+    Halfedge* dual_line; //pointer to left-most halfedge corresponding to this Anchor in the arrangement
     unsigned position; //relative position of Anchor line at sweep line, used for Bentley-Ottmann DCEL construction algorithm
     bool above_line; //true iff this Anchor is above the current slice line, used for the vineyard-update process of storing persistence data in cells of the arrangement
     unsigned long weight; //estimate of the cost of updating the RU-decomposition when crossing this anchor

--- a/dcel/arrangement.cpp
+++ b/dcel/arrangement.cpp
@@ -518,7 +518,7 @@ long Arrangement::AID(Anchor* a) const
             return i;
         ++it;
     }
-    debug() << "WARNING: no anchor found for " << a;
+    debug() << "WARNING: no anchor found.";//" for " << *a;
     //we should only get here if f is nullptr (meaning the unbounded, outside face)
     return -1;
 }

--- a/dcel/arrangement.cpp
+++ b/dcel/arrangement.cpp
@@ -287,6 +287,7 @@ Anchor* Arrangement::find_least_upper_anchor(double y_coord)
     unsigned int zero = 0; //disambiguate the following function call
     auto test = new Anchor(zero, best);
     auto it = all_anchors.lower_bound(test);
+    delete test;
 
     if (it == all_anchors.end()) //not found
     {

--- a/dcel/arrangement.cpp
+++ b/dcel/arrangement.cpp
@@ -343,7 +343,6 @@ void Arrangement::announce_next_point(Halfedge* finger, Vertex* next_pt)
 //find a 2-cell containing the specified point
 Face* Arrangement::find_point(double x_coord, double y_coord)
 {
-    std::cerr << "find_point " << x_coord << ", " << y_coord << std::endl;
     //start on the left edge of the arrangement, at the correct y-coordinate
     auto start = find_least_upper_anchor(-1 * y_coord);
 

--- a/dcel/arrangement.cpp
+++ b/dcel/arrangement.cpp
@@ -518,7 +518,7 @@ long Arrangement::AID(Anchor* a) const
             return i;
         ++it;
     }
-
+    Debug() << "WARNING: no anchor found for " << *a;
     //we should only get here if f is nullptr (meaning the unbounded, outside face)
     return -1;
 }

--- a/dcel/arrangement.cpp
+++ b/dcel/arrangement.cpp
@@ -518,7 +518,7 @@ long Arrangement::AID(Anchor* a) const
             return i;
         ++it;
     }
-    Debug() << "WARNING: no anchor found for " << *a;
+    debug() << "WARNING: no anchor found for " << a;
     //we should only get here if f is nullptr (meaning the unbounded, outside face)
     return -1;
 }

--- a/dcel/arrangement.cpp
+++ b/dcel/arrangement.cpp
@@ -62,15 +62,15 @@ Arrangement::Arrangement(std::vector<exact> xe,
     , verbosity(verbosity)
 {
     //create vertices
-    vertices.push_back(std::make_shared<Vertex>(0, INFTY)); //index 0
-    vertices.push_back(std::make_shared<Vertex>(INFTY, INFTY)); //index 1
-    vertices.push_back(std::make_shared<Vertex>(INFTY, -INFTY)); //index 2
-    vertices.push_back(std::make_shared<Vertex>(0, -INFTY)); //index 3
+    vertices.push_back(new Vertex(0, INFTY)); //index 0
+    vertices.push_back(new Vertex(INFTY, INFTY)); //index 1
+    vertices.push_back(new Vertex(INFTY, -INFTY)); //index 2
+    vertices.push_back(new Vertex(0, -INFTY)); //index 3
 
     //create halfedges
     for (int i = 0; i < 4; i++) {
-        halfedges.push_back(std::make_shared<Halfedge>(vertices[i], std::shared_ptr<Anchor>(nullptr))); //index 0, 2, 4, 6 (inside halfedges)
-        halfedges.push_back(std::make_shared<Halfedge>(vertices[(i + 1) % 4], std::shared_ptr<Anchor>(nullptr))); //index 1, 3, 5, 7 (outside halfedges)
+        halfedges.push_back(new Halfedge(vertices[i], nullptr)); //index 0, 2, 4, 6 (inside halfedges)
+        halfedges.push_back(new Halfedge(vertices[(i + 1) % 4], nullptr)); //index 1, 3, 5, 7 (outside halfedges)
         halfedges[2 * i]->set_twin(halfedges[2 * i + 1]);
         halfedges[2 * i + 1]->set_twin(halfedges[2 * i]);
     }
@@ -86,39 +86,53 @@ Arrangement::Arrangement(std::vector<exact> xe,
     }
 
     //create face
-    faces.push_back(std::make_shared<Face>(halfedges[0], faces.size()));
+    faces.push_back(new Face(halfedges[0], faces.size()));
 
     //set the remaining pointers on the halfedges
     for (int i = 0; i < 4; i++) {
-        std::shared_ptr<Halfedge> inside = halfedges[2 * i];
+        Halfedge* inside = halfedges[2 * i];
         inside->set_next(halfedges[(2 * i + 2) % 8]);
         inside->set_prev(halfedges[(2 * i + 6) % 8]);
         inside->set_face(faces[0]);
 
-        std::shared_ptr<Halfedge> outside = halfedges[2 * i + 1];
+        Halfedge* outside = halfedges[2 * i + 1];
         outside->set_next(halfedges[(2 * i + 7) % 8]);
         outside->set_prev(halfedges[(2 * i + 3) % 8]);
     }
 } //end constructor
 
+Arrangement::~Arrangement() {
+    for(auto face : faces) {
+        delete face;
+    }
+    for(auto halfedge: halfedges) {
+        delete halfedge;
+    }
+    for(auto anchor: all_anchors) {
+        delete anchor;
+    }
+    for(auto vertex: vertices) {
+        delete vertex;
+    }
+}
 //inserts a new vertex on the specified edge, with the specified coordinates, and updates all relevant pointers
 //  i.e. new vertex is between initial and termainal points of the specified edge
 //returns pointer to a new halfedge, whose initial point is the new vertex, and that follows the specified edge around its face
-std::shared_ptr<Halfedge> Arrangement::insert_vertex(std::shared_ptr<Halfedge> edge, double x, double y)
+Halfedge* Arrangement::insert_vertex(Halfedge* edge, double x, double y)
 {
     //create new vertex
-    std::shared_ptr<Vertex> new_vertex = std::make_shared<Vertex>(x, y);
-    vertices.push_back(new_vertex);
+    vertices.push_back(new Vertex(x, y));
+    auto new_vertex = vertices.back();
 
     //get twin and Anchor of this edge
-    std::shared_ptr<Halfedge> twin = edge->get_twin();
-    std::shared_ptr<Anchor> anchor = edge->get_anchor();
+    auto twin = edge->get_twin();
+    auto anchor = edge->get_anchor();
 
     //create new halfedges
-    std::shared_ptr<Halfedge> up = std::make_shared<Halfedge>(new_vertex, anchor);
-    halfedges.push_back(up);
-    std::shared_ptr<Halfedge> dn = std::make_shared<Halfedge>(new_vertex, anchor);
-    halfedges.push_back(dn);
+    halfedges.push_back(new Halfedge(new_vertex, anchor));
+    auto up = halfedges.back();
+    halfedges.push_back(new Halfedge(new_vertex, anchor));
+    auto dn = halfedges.back();
 
     //update pointers
     up->set_next(edge->get_next());
@@ -150,17 +164,18 @@ std::shared_ptr<Halfedge> Arrangement::insert_vertex(std::shared_ptr<Halfedge> e
 //creates the first pair of Halfedges in an Anchor line, anchored on the left edge of the strip at origin of specified edge
 //  also creates a new face (the face below the new edge)
 //  CAUTION: leaves nullptr: new_edge.next and new_twin.prev
-std::shared_ptr<Halfedge> Arrangement::create_edge_left(std::shared_ptr<Halfedge> edge, std::shared_ptr<Anchor> anchor)
+Halfedge* Arrangement::create_edge_left(Halfedge* edge, Anchor* anchor)
 {
     //create new halfedges
-    std::shared_ptr<Halfedge> new_edge(new Halfedge(edge->get_origin(), anchor)); //points AWAY FROM left edge
-    halfedges.push_back(new_edge);
-    std::shared_ptr<Halfedge> new_twin(new Halfedge(nullptr, anchor)); //points TOWARDS left edge
-    halfedges.push_back(new_twin);
+    ; //points AWAY FROM left edge
+    halfedges.push_back(new Halfedge(edge->get_origin(), anchor));
+    auto new_edge = halfedges.back();
+    halfedges.push_back(new Halfedge(nullptr, anchor)); //points TOWARDS left edge
+    auto new_twin = halfedges.back();
 
     //create new face
-    std::shared_ptr<Face> new_face(new Face(new_edge, faces.size()));
-    faces.push_back(new_face);
+    faces.push_back(new Face(new_edge, faces.size()));
+    auto new_face = faces.back();
 
     //update Halfedge pointers
     new_edge->set_prev(edge->get_prev());
@@ -187,7 +202,7 @@ std::shared_ptr<Halfedge> Arrangement::create_edge_left(std::shared_ptr<Halfedge
 BarcodeTemplate& Arrangement::get_barcode_template(double degrees, double offset)
 {
     ///TODO: store some point/cell to seed the next query
-    std::shared_ptr<Face> cell;
+    Face* cell;
     if (degrees == 90) //then line is vertical
     {
         cell = find_vertical_line(-1 * offset); //multiply by -1 to correct for orientation of offset
@@ -196,7 +211,7 @@ BarcodeTemplate& Arrangement::get_barcode_template(double degrees, double offset
         }
 
     } else if (degrees == 0) { //then line is horizontal
-        std::shared_ptr<Anchor> anchor = find_least_upper_anchor(offset);
+        auto anchor = find_least_upper_anchor(offset);
 
         if (anchor != nullptr)
             cell = anchor->get_line()->get_face();
@@ -240,16 +255,16 @@ unsigned Arrangement::num_faces()
 //creates a new anchor in the vector all_anchors
 void Arrangement::add_anchor(Anchor anchor)
 {
-    all_anchors.insert(std::make_shared<Anchor>(anchor.get_entry()));
+    all_anchors.insert(new Anchor(anchor.get_entry()));
 }
 
 //finds the first anchor that intersects the left edge of the arrangement at a point not less than the specified y-coordinate
 //  if no such anchor, returns nullptr
-std::shared_ptr<Anchor> Arrangement::find_least_upper_anchor(double y_coord)
+Anchor* Arrangement::find_least_upper_anchor(double y_coord)
 {
     //binary search to find greatest y-grade not greater than than y_coord
     unsigned best = 0;
-    if (y_grades.size() >= 1 && y_grades[0] <= y_coord) {
+    if ((!y_grades.empty()) && y_grades[0] <= y_coord) {
         //binary search the vector y_grades
         unsigned min = 0;
         unsigned max = y_grades.size() - 1;
@@ -270,20 +285,20 @@ std::shared_ptr<Anchor> Arrangement::find_least_upper_anchor(double y_coord)
     //if we get here, then y_grades[best] is the greatest y-grade not greater than y_coord
     //now find Anchor whose line intersects the left edge of the arrangement lowest, but not below y_grade[best]
     unsigned int zero = 0; //disambiguate the following function call
-    std::shared_ptr<Anchor> test(new Anchor(zero, best));
-    std::set<std::shared_ptr<Anchor>, PointerComparator<Anchor, Anchor_LeftComparator>>::iterator it = all_anchors.lower_bound(test);
+    auto test = new Anchor(zero, best);
+    auto it = all_anchors.lower_bound(test);
 
     if (it == all_anchors.end()) //not found
     {
         return nullptr;
     }
     //else
-    return *it;
+    return (*it);
 } //end find_least_upper_anchor()
 
 //finds the (unbounded) cell associated to dual point of the vertical line with the given x-coordinate
 //  i.e. finds the Halfedge whose Anchor x-coordinate is the largest such coordinate not larger than than x_coord; returns the Face corresponding to that Halfedge
-std::shared_ptr<Face> Arrangement::find_vertical_line(double x_coord)
+Face* Arrangement::find_vertical_line(double x_coord)
 {
     //is there an Anchor with x-coordinate not greater than x_coord?
     if (vertical_line_query_list.size() >= 1
@@ -295,7 +310,7 @@ std::shared_ptr<Face> Arrangement::find_vertical_line(double x_coord)
 
         while (max >= min) {
             unsigned mid = (max + min) / 2;
-            std::shared_ptr<Anchor> test = vertical_line_query_list[mid]->get_anchor();
+            auto test = vertical_line_query_list[mid]->get_anchor();
 
             if (x_grades[test->get_x()] <= x_coord) //found a lower bound, but search upper subarray for a better lower bound
             {
@@ -313,7 +328,7 @@ std::shared_ptr<Face> Arrangement::find_vertical_line(double x_coord)
 
 } //end find_vertical_line()
 
-void Arrangement::announce_next_point(std::shared_ptr<Halfedge> finger, std::shared_ptr<Vertex> next_pt)
+void Arrangement::announce_next_point(Halfedge* finger, Vertex* next_pt)
 {
 
     if (verbosity >= 10) {
@@ -325,12 +340,13 @@ void Arrangement::announce_next_point(std::shared_ptr<Halfedge> finger, std::sha
 }
 
 //find a 2-cell containing the specified point
-std::shared_ptr<Face> Arrangement::find_point(double x_coord, double y_coord)
+Face* Arrangement::find_point(double x_coord, double y_coord)
 {
+    std::cerr << "find_point " << x_coord << ", " << y_coord << std::endl;
     //start on the left edge of the arrangement, at the correct y-coordinate
-    std::shared_ptr<Anchor> start = find_least_upper_anchor(-1 * y_coord);
+    auto start = find_least_upper_anchor(-1 * y_coord);
 
-    std::shared_ptr<Halfedge> finger = nullptr; //for use in finding the cell
+    Halfedge* finger = nullptr; //for use in finding the cell
 
     if (start == nullptr) //then starting point is in the top (unbounded) cell
     {
@@ -345,7 +361,7 @@ std::shared_ptr<Face> Arrangement::find_point(double x_coord, double y_coord)
         }
     }
 
-    std::shared_ptr<Face> cell = nullptr; //will later point to the cell containing the specified point
+    Face* cell = nullptr; //will later point to the cell containing the specified point
 
     while (cell == nullptr) //while not found
     {
@@ -354,7 +370,7 @@ std::shared_ptr<Face> Arrangement::find_point(double x_coord, double y_coord)
         }
 
         //find the edge of the current cell that crosses the horizontal line at y_coord
-        std::shared_ptr<Vertex> next_pt = finger->get_next()->get_origin();
+        Vertex* next_pt = finger->get_next()->get_origin();
 
         announce_next_point(finger, next_pt);
 
@@ -376,7 +392,7 @@ std::shared_ptr<Face> Arrangement::find_point(double x_coord, double y_coord)
             } else //move to adjacent cell
             {
                 //find degree of vertex
-                std::shared_ptr<Halfedge> thumb = finger->get_next();
+                auto thumb = finger->get_next();
                 int deg = 1;
                 while (thumb != finger->get_twin()) {
                     thumb = thumb->get_twin()->get_next();
@@ -396,7 +412,7 @@ std::shared_ptr<Face> Arrangement::find_point(double x_coord, double y_coord)
                 cell = finger->get_face();
             } else //then edge is not vertical
             {
-                std::shared_ptr<Anchor> temp = finger->get_anchor();
+                Anchor* temp = finger->get_anchor();
                 double x_pos = (y_coord + y_grades[temp->get_y()]) / x_grades[temp->get_x()]; //NOTE: division by zero never occurs because we are searching along a horizontal line, and thus we never cross horizontal lines in the arrangement
 
                 if (x_pos >= x_coord) //found the cell
@@ -439,8 +455,8 @@ void Arrangement::print()
 
     debug() << "  Halfedges";
     for (unsigned i = 0; i < halfedges.size(); i++) {
-        std::shared_ptr<Halfedge> e = halfedges[i];
-        std::shared_ptr<Halfedge> t = e->get_twin();
+        auto e = halfedges[i];
+        auto t = e->get_twin();
         debug() << "    halfedge " << i << ": " << *(e->get_origin()) << "--" << *(t->get_origin()) << "; ";
         if (e->get_anchor() == nullptr)
             debug() << "Anchor null; ";
@@ -455,7 +471,7 @@ void Arrangement::print()
     }
 
     debug() << "  Anchor set: ";
-    std::set<std::shared_ptr<Anchor>>::iterator it;
+    std::set<Anchor*>::iterator it;
     for (it = all_anchors.begin(); it != all_anchors.end(); ++it) {
         Anchor cur = **it;
         debug() << "(" << cur.get_x() << ", " << cur.get_y() << ") halfedge " << HID(cur.get_line()) << "; ";
@@ -463,7 +479,7 @@ void Arrangement::print()
 } //end print()
 
 template <typename T>
-long index_of(std::vector<T> const& vec, T const& t)
+long index_of(std::vector<T*> const& vec, T const* t)
 {
     for (size_t i = 0; i < vec.size(); i++) {
         if (vec[i] == t)
@@ -474,26 +490,26 @@ long index_of(std::vector<T> const& vec, T const& t)
 
 //look up halfedge ID, used in print() for debugging
 // HID = halfedge ID
-long Arrangement::HID(std::shared_ptr<Halfedge> h) const
+long Arrangement::HID(Halfedge* h) const
 {
     return index_of(halfedges, h);
 }
 
 //look up face ID, used in print() for debugging
 // FID = face ID
-long Arrangement::FID(std::shared_ptr<Face> f) const
+long Arrangement::FID(Face* f) const
 {
     return index_of(faces, f);
 }
 
 //look up vertex ID, used in print() for debugging
 // VID = vertex ID
-long Arrangement::VID(std::shared_ptr<Vertex> v) const
+long Arrangement::VID(Vertex* v) const
 {
     return index_of(vertices, v);
 }
 
-long Arrangement::AID(std::shared_ptr<Anchor> a) const
+long Arrangement::AID(Anchor* a) const
 {
     auto it = all_anchors.begin();
 
@@ -515,8 +531,8 @@ void Arrangement::test_consistency()
     bool face_problem = false;
     std::set<int> edges_found_in_faces;
 
-    for (std::vector<std::shared_ptr<Face>>::iterator it = faces.begin(); it != faces.end(); ++it) {
-        std::shared_ptr<Face> face = *it;
+    for (auto it = faces.begin(); it != faces.end(); ++it) {
+        auto face = (*it);
         if (verbosity >= 10) {
             //FID calls are expensive
             //TODO put an ID field in Face and others?
@@ -526,7 +542,7 @@ void Arrangement::test_consistency()
             debug() << "    PROBLEM: face" << FID(face) << "has null edge pointer.";
             face_problem = true;
         } else {
-            std::shared_ptr<Halfedge> start = face->get_boundary();
+            auto start = face->get_boundary();
             edges_found_in_faces.insert(HID(start));
 
             if (start->get_face() != face) {
@@ -537,7 +553,7 @@ void Arrangement::test_consistency()
             if (start->get_next() == nullptr)
                 debug() << "    PROBLEM: starting halfedge" << HID(start) << "of face" << FID(face) << "has nullptr next pointer.";
             else {
-                std::shared_ptr<Halfedge> cur = start->get_next();
+                auto cur = start->get_next();
                 int i = 0;
                 while (cur != start) {
                     edges_found_in_faces.insert(HID(cur));
@@ -574,8 +590,8 @@ void Arrangement::test_consistency()
     if (halfedges.size() < 2) {
         debug() << "Only " << halfedges.size() << "halfedges present!";
     }
-    std::shared_ptr<Halfedge> start = halfedges[1];
-    std::shared_ptr<Halfedge> cur = start;
+    auto start = halfedges[1];
+    auto cur = start;
     do {
         edges_found_in_faces.insert(HID(cur));
 
@@ -602,11 +618,11 @@ void Arrangement::test_consistency()
     bool curve_problem = false;
     std::set<int> edges_found_in_curves;
 
-    for (std::set<std::shared_ptr<Anchor>>::iterator it = all_anchors.begin(); it != all_anchors.end(); ++it) {
-        std::shared_ptr<Anchor> anchor = *it;
+    for (auto it = all_anchors.begin(); it != all_anchors.end(); ++it) {
+        auto anchor = *it;
         debug() << "  Checking line for anchor (" << anchor->get_x() << "," << anchor->get_y() << ")";
 
-        std::shared_ptr<Halfedge> edge = anchor->get_line();
+        Halfedge* edge = anchor->get_line();
         do {
             edges_found_in_curves.insert(HID(edge));
             edges_found_in_curves.insert(HID(edge->get_twin()));
@@ -666,7 +682,7 @@ void Arrangement::test_consistency()
 
     //check anchor lines
     debug() << "Checking order of vertices along right edge of the strip:";
-    std::shared_ptr<Halfedge> redge = halfedges[3];
+    auto redge = halfedges[3];
     while (redge != halfedges[1]) {
         debug() << " y = " << redge->get_origin()->get_y() << "at vertex" << VID(redge->get_origin());
         redge = redge->get_next();
@@ -677,7 +693,7 @@ void Arrangement::test_consistency()
 
 //Crossing constructor
 //precondition: Anchors a and b must be comparable
-Arrangement::Crossing::Crossing(std::shared_ptr<Anchor> a, std::shared_ptr<Anchor> b, std::shared_ptr<Arrangement> m)
+Arrangement::Crossing::Crossing(Anchor* a, Anchor* b, Arrangement* m)
     : a(a)
     , b(b)
     , m(m)
@@ -712,7 +728,7 @@ bool Arrangement::CrossingComparator::operator()(const Crossing& c1, const Cross
         throw std::runtime_error("Inverted crossing error");
     }
 
-    std::shared_ptr<Arrangement> m = c1.m; //makes it easier to reference arrays in the arrangement
+    Arrangement* m = c1.m; //makes it easier to reference arrays in the arrangement
 
     //now do the comparison
     //if the x-coordinates are nearly equal as double values, then compare exact values

--- a/dcel/arrangement.h
+++ b/dcel/arrangement.h
@@ -63,6 +63,8 @@ public:
 
     ~Arrangement();
 
+    Arrangement(const Arrangement& that) = delete;
+
     //returns barcode template associated with the specified line (point)
     BarcodeTemplate& get_barcode_template(double degrees, double offset);
 

--- a/dcel/arrangement.h
+++ b/dcel/arrangement.h
@@ -46,6 +46,7 @@ class Vertex;
 
 class ArrangementMessage;
 
+
 class Arrangement {
     //TODO: refactor so Arrangement doesn't need friends.
     friend class PersistenceUpdater;
@@ -59,6 +60,8 @@ public:
     //constructor; sets up bounding box (with empty interior) for the affine Grassmannian
     //  requires references to vectors of all multi-grade values (both double and exact values)
     Arrangement(std::vector<exact> xe, std::vector<exact> ye, unsigned verbosity);
+
+    ~Arrangement();
 
     //returns barcode template associated with the specified line (point)
     BarcodeTemplate& get_barcode_template(double degrees, double offset);
@@ -87,42 +90,42 @@ public:
 
     friend std::ostream& operator<<(std::ostream&, const Arrangement&);
     friend std::istream& operator>>(std::istream&, Arrangement&);
-    std::shared_ptr<Halfedge> insert_vertex(std::shared_ptr<Halfedge> edge, double x, double y); //inserts a new vertex on the specified edge, with the specified coordinates, and updates all relevant pointers
+    Halfedge* insert_vertex(Halfedge* edge, double x, double y); //inserts a new vertex on the specified edge, with the specified coordinates, and updates all relevant pointers
 
 private:
     //data structures
     std::vector<double> x_grades; //floating-point values for x-grades
     std::vector<double> y_grades; //floating-point values for y-grades
-    std::vector<std::shared_ptr<Vertex>> vertices; //all vertices in the arrangement
-    std::vector<std::shared_ptr<Halfedge>> halfedges; //all halfedges in the arrangement
-    std::vector<std::shared_ptr<Face>> faces; //all faces in the arrangement
+    std::vector<Vertex*> vertices; //all vertices in the arrangement
+    std::vector<Halfedge*> halfedges; //all halfedges in the arrangement
+    std::vector<Face*> faces; //all faces in the arrangement
 
     unsigned verbosity;
 
     //set of Anchors that are represented in the arrangement, ordered by position of curve along left side of the arrangement, from bottom to top
-    std::set<std::shared_ptr<Anchor>, PointerComparator<Anchor, Anchor_LeftComparator>> all_anchors;
+    std::set<Anchor*, PointerComparator<Anchor, Anchor_LeftComparator>> all_anchors;
 
-    std::shared_ptr<Halfedge> topleft; //pointer to Halfedge that points down from top left corner (0,infty)
-    std::shared_ptr<Halfedge> topright; //pointer to Halfedge that points down from the top right corner (infty,infty)
-    std::shared_ptr<Halfedge> bottomleft; //pointer to Halfedge that points up from bottom left corner (0,-infty)
-    std::shared_ptr<Halfedge> bottomright; //pointer to Halfedge that points up from bottom right corner (infty,-infty)
+    Halfedge* topleft; //pointer to Halfedge that points down from top left corner (0,infty)
+    Halfedge* topright; //pointer to Halfedge that points down from the top right corner (infty,infty)
+    Halfedge* bottomleft; //pointer to Halfedge that points up from bottom left corner (0,-infty)
+    Halfedge* bottomright; //pointer to Halfedge that points up from bottom right corner (infty,-infty)
 
     //stores a pointer to the rightmost Halfedge of the "top" line of each unique slope, ordered from small slopes to big slopes (each Halfedge points to Anchor and Face for vertical-line queries)
-    std::vector<std::shared_ptr<Halfedge>> vertical_line_query_list;
+    std::vector<Halfedge*> vertical_line_query_list;
 
     ///// functions for creating the arrangement /////
 
     //creates the first pair of Halfedges in an anchor line, anchored on the left edge of the strip
-    std::shared_ptr<Halfedge> create_edge_left(std::shared_ptr<Halfedge> edge, std::shared_ptr<Anchor> anchor);
+    Halfedge* create_edge_left(Halfedge* edge, Anchor* anchor);
 
     //computes and stores the edge weight for each anchor line
     void find_edge_weights(PersistenceUpdater& updater);
 
     //finds a pseudo-optimal path through all 2-cells of the arrangement
-    void find_path(std::vector<std::shared_ptr<Halfedge>>& pathvec);
+    void find_path(std::vector<Halfedge*>& pathvec);
 
     //builds the path recursively
-    void find_subpath(unsigned cur_node, std::vector<std::vector<unsigned>>& adj, std::vector<std::shared_ptr<Halfedge>>& pathvec, bool return_path);
+    void find_subpath(unsigned cur_node, std::vector<std::vector<unsigned>>& adj, std::vector<Halfedge*>& pathvec, bool return_path);
 
     //stores (a copy of) the given barcode template in faces[i]; used for re-building the arrangement from a RIVET data file
     void set_barcode_template(unsigned i, BarcodeTemplate& bt);
@@ -130,33 +133,32 @@ private:
     ///// functions for searching the arrangement /////
 
     //finds the first anchor that intersects the left edge of the arrangement at a point not less than the specified y-coordinate; if no such anchor, returns NULL
-    std::shared_ptr<Anchor> find_least_upper_anchor(double y_coord);
+    Anchor* find_least_upper_anchor(double y_coord);
 
     //finds the (unbounded) cell associated to dual point of the vertical line with the given x-coordinate
     //  i.e. finds the Halfedge whose anchor x-coordinate is the largest such coordinate not larger than than x_coord; returns the Face corresponding to that Halfedge
-    std::shared_ptr<Face> find_vertical_line(double x_coord);
+    Face* find_vertical_line(double x_coord);
 
     //finds a 2-cell containing the specified point
-    std::shared_ptr<Face> find_point(double x_coord, double y_coord);
+    Face* find_point(double x_coord, double y_coord);
 
     ///// functions for testing /////
 
     long HID(Halfedge* h) const; //halfedge ID, for printing and debugging
-    long HID(std::shared_ptr<Halfedge> h) const; //halfedge ID, for printing and debugging
-    long FID(std::shared_ptr<Face> f) const; //face ID, for printing and debugging
-    long AID(std::shared_ptr<Anchor> a) const; //anchor ID, for printing and debugging
-    long VID(std::shared_ptr<Vertex> v) const; //vertex ID, for printing and debugging
+    long FID(Face* f) const; //face ID, for printing and debugging
+    long AID(Anchor* a) const; //anchor ID, for printing and debugging
+    long VID(Vertex* v) const; //vertex ID, for printing and debugging
 
-    void announce_next_point(std::shared_ptr<Halfedge> finder, std::shared_ptr<Vertex> next_pt);
+    void announce_next_point(Halfedge* finder, Vertex* next_pt);
 
     //struct to hold a future intersection event -- used when building the arrangement
     struct Crossing {
-        std::shared_ptr<Anchor> a; //pointer to one line
-        std::shared_ptr<Anchor> b; //pointer to the other line -- must ensure that line for anchor a is below line for anchor b just before the crossing point!!!!!
+        Anchor* a; //pointer to one line
+        Anchor* b; //pointer to the other line -- must ensure that line for anchor a is below line for anchor b just before the crossing point!!!!!
         double x; //x-coordinate of intersection point (floating-point)
-        std::shared_ptr<Arrangement> m; //pointer to the arrangement, so the Crossing has access to the vectors x_grades, x_exact, y_grades, and y_exact
+        Arrangement* m; //pointer to the arrangement, so the Crossing has access to the vectors x_grades, x_exact, y_grades, and y_exact
 
-        Crossing(std::shared_ptr<Anchor> a, std::shared_ptr<Anchor> b, std::shared_ptr<Arrangement> m); //precondition: Anchors a and b must be comparable
+        Crossing(Anchor* a, Anchor* b, Arrangement* m); //precondition: Anchors a and b must be comparable
         bool x_equal(const Crossing* other) const; //returns true iff this Crossing has (exactly) the same x-coordinate as other Crossing
     };
 

--- a/dcel/arrangement_builder.cpp
+++ b/dcel/arrangement_builder.cpp
@@ -64,7 +64,7 @@ std::shared_ptr<Arrangement> ArrangementBuilder::build_arrangement(MultiBetti& m
     //now that we have all the anchors, we can build the interior of the arrangement
     progress.progress(25);
     timer.restart();
-    build_interior(arrangement);
+    build_interior(*arrangement);
     if (verbosity >= 2) {
         debug() << "Line arrangement constructed; this took " << timer.elapsed() << " milliseconds.";
         if (verbosity >= 4) {
@@ -82,7 +82,7 @@ std::shared_ptr<Arrangement> ArrangementBuilder::build_arrangement(MultiBetti& m
 
     //now that the arrangement is constructed, we can find a path -- NOTE: path starts with a (near-vertical) line to the right of all multigrades
     progress.progress(75);
-    std::vector<std::shared_ptr<Halfedge>> path;
+    std::vector<Halfedge*> path;
     timer.restart();
     find_path(*arrangement, path);
     if (verbosity >= 2) {
@@ -120,7 +120,7 @@ std::shared_ptr<Arrangement> ArrangementBuilder::build_arrangement(std::vector<e
     //now that we have all the anchors, we can build the interior of the arrangement
     progress.progress(30);
     timer.restart();
-    build_interior(arrangement); ///TODO: build_interior() should update its status!
+    build_interior(*arrangement); ///TODO: build_interior() should update its status!
     if (verbosity >= 2) {
         debug() << "Line arrangement constructed; this took " << timer.elapsed() << " milliseconds.";
         if (verbosity >= 4) {
@@ -149,28 +149,28 @@ std::shared_ptr<Arrangement> ArrangementBuilder::build_arrangement(std::vector<e
 //preconditions:
 //   all Anchors are in a list, ordered by Anchor_LeftComparator
 //   boundary of the arrangement is created (as in the arrangement constructor)
-void ArrangementBuilder::build_interior(std::shared_ptr<Arrangement> arrangement)
+void ArrangementBuilder::build_interior(Arrangement &arrangement)
 {
     if (verbosity >= 8) {
         debug() << "BUILDING ARRANGEMENT:  Anchors sorted for left edge of strip: ";
-        for (std::set<std::shared_ptr<Anchor>, Anchor_LeftComparator>::iterator it = arrangement->all_anchors.begin();
-             it != arrangement->all_anchors.end(); ++it)
+        for (auto it = arrangement.all_anchors.begin();
+             it != arrangement.all_anchors.end(); ++it)
             debug(true) << "(" << (*it)->get_x() << "," << (*it)->get_y() << ") ";
     }
 
     // DATA STRUCTURES
 
     //data structure for ordered list of lines
-    std::vector<std::shared_ptr<Halfedge>> lines;
-    lines.reserve(arrangement->all_anchors.size());
+    std::vector<Halfedge*> lines;
+    lines.reserve(arrangement.all_anchors.size());
 
     //data structure for queue of future intersections
-    std::priority_queue<std::shared_ptr<Arrangement::Crossing>,
-            std::vector<std::shared_ptr<Arrangement::Crossing>>,
+    std::priority_queue<Arrangement::Crossing*,
+            std::vector<Arrangement::Crossing*>,
             PointerComparator<Arrangement::Crossing, Arrangement::CrossingComparator>> crossings;
 
     //data structure for all pairs of Anchors whose potential crossings have been considered
-    typedef std::pair<std::shared_ptr<Anchor>, std::shared_ptr<Anchor>> Anchor_pair;
+    typedef std::pair<Anchor*, Anchor*> Anchor_pair;
     std::set<Anchor_pair> considered_pairs;
 
     // PART 1: INSERT VERTICES AND EDGES ALONG LEFT EDGE OF THE ARRANGEMENT
@@ -179,11 +179,11 @@ void ArrangementBuilder::build_interior(std::shared_ptr<Arrangement> arrangement
     }
 
     //for each Anchor, create vertex and associated halfedges, anchored on the left edge of the strip
-    std::shared_ptr<Halfedge> leftedge = arrangement->bottomleft;
+    auto leftedge = arrangement.bottomleft;
     unsigned prev_y = std::numeric_limits<unsigned>::max();
-    for (std::set<std::shared_ptr<Anchor>, Anchor_LeftComparator>::iterator it = arrangement->all_anchors.begin();
-         it != arrangement->all_anchors.end(); ++it) {
-        std::shared_ptr<Anchor> cur_anchor = *it;
+    for (auto it = arrangement.all_anchors.begin();
+         it != arrangement.all_anchors.end(); ++it) {
+        auto cur_anchor = *it;
 
         if (verbosity >= 10) {
             debug() << "  Processing Anchor"
@@ -192,13 +192,13 @@ void ArrangementBuilder::build_interior(std::shared_ptr<Arrangement> arrangement
 
         if (cur_anchor->get_y() != prev_y) //then create new vertex
         {
-            double dual_point_y_coord = -1 * arrangement->y_grades[cur_anchor->get_y()]; //point-line duality requires multiplying by -1
-            leftedge = arrangement->insert_vertex(leftedge, 0, dual_point_y_coord); //set leftedge to edge that will follow the new edge
+            double dual_point_y_coord = -1 * arrangement.y_grades[cur_anchor->get_y()]; //point-line duality requires multiplying by -1
+            leftedge = arrangement.insert_vertex(leftedge, 0, dual_point_y_coord); //set leftedge to edge that will follow the new edge
             prev_y = cur_anchor->get_y(); //remember the discrete y-index
         }
 
         //now insert new edge at origin vertex of leftedge
-        std::shared_ptr<Halfedge> new_edge = arrangement->create_edge_left(leftedge, cur_anchor);
+        auto new_edge = arrangement.create_edge_left(leftedge, cur_anchor);
 
         //remember Halfedge corresponding to this Anchor
         lines.push_back(new_edge);
@@ -212,10 +212,10 @@ void ArrangementBuilder::build_interior(std::shared_ptr<Arrangement> arrangement
 
     //for each pair of consecutive lines, if they intersect, store the intersection
     for (unsigned i = 0; i + 1 < lines.size(); i++) {
-        std::shared_ptr<Anchor> a = lines[i]->get_anchor();
-        std::shared_ptr<Anchor> b = lines[i + 1]->get_anchor();
+        auto a = lines[i]->get_anchor();
+        auto b = lines[i + 1]->get_anchor();
         if (a->comparable(*b)) //then the Anchors are (strongly) comparable, so we must store an intersection
-            crossings.push(std::make_shared<Arrangement::Crossing>(a, b, arrangement));
+            crossings.push(new Arrangement::Crossing(a, b, &arrangement));
 
         //remember that we have now considered this intersection
         considered_pairs.insert(Anchor_pair(a, b));
@@ -231,7 +231,7 @@ void ArrangementBuilder::build_interior(std::shared_ptr<Arrangement> arrangement
     int status_interval = 10000; //controls frequency of output
 
     //current position of sweep line
-    std::shared_ptr<Arrangement::Crossing> sweep = NULL;
+    Arrangement::Crossing *sweep = nullptr;
 
     while (!crossings.empty()) {
         //get the next intersection from the queue
@@ -250,7 +250,7 @@ void ArrangementBuilder::build_interior(std::shared_ptr<Arrangement> arrangement
         }
 
         //find out if more than two curves intersect at this point
-        while (!crossings.empty() && sweep->x_equal(crossings.top().get()) && (cur->b == crossings.top()->a)) {
+        while (!crossings.empty() && sweep->x_equal(crossings.top()) && (cur->b == crossings.top()->a)) {
             cur = crossings.top();
             crossings.pop();
 
@@ -262,7 +262,7 @@ void ArrangementBuilder::build_interior(std::shared_ptr<Arrangement> arrangement
         }
 
         //compute y-coordinate of intersection
-        double intersect_y = arrangement->x_grades[sweep->a->get_x()] * (sweep->x) - arrangement->y_grades[sweep->a->get_y()];
+        double intersect_y = arrangement.x_grades[sweep->a->get_x()] * (sweep->x) - arrangement.y_grades[sweep->a->get_y()];
 
         if (verbosity >= 10) {
             debug() << "  found intersection between"
@@ -270,23 +270,23 @@ void ArrangementBuilder::build_interior(std::shared_ptr<Arrangement> arrangement
         }
 
         //create new vertex
-        auto new_vertex = std::make_shared<Vertex>(sweep->x, intersect_y);
-        arrangement->vertices.push_back(new_vertex);
+        auto new_vertex = new Vertex(sweep->x, intersect_y);
+        arrangement.vertices.push_back(new_vertex);
 
         //anchor edges to vertex and create new face(s) and edges	//TODO: check this!!!
-        std::shared_ptr<Halfedge> prev_new_edge = NULL; //necessary to remember the previous new edge at each interation of the loop
-        std::shared_ptr<Halfedge> first_incoming = lines[first_pos]; //necessary to remember the first incoming edge
-        std::shared_ptr<Halfedge> prev_incoming = NULL; //necessary to remember the previous incoming edge at each iteration of the loop
+        Halfedge* prev_new_edge = NULL; //necessary to remember the previous new edge at each interation of the loop
+        Halfedge* first_incoming = lines[first_pos]; //necessary to remember the first incoming edge
+        Halfedge* prev_incoming = NULL; //necessary to remember the previous incoming edge at each iteration of the loop
         for (unsigned cur_pos = first_pos; cur_pos <= last_pos; cur_pos++) {
             //anchor edge to vertex
-            std::shared_ptr<Halfedge> incoming = lines[cur_pos];
+            auto incoming = lines[cur_pos];
             incoming->get_twin()->set_origin(new_vertex);
 
             //create next pair of twin halfedges along the current curve (i.e. curves[incident_edges[i]] )
-            std::shared_ptr<Halfedge> new_edge(new Halfedge(new_vertex, incoming->get_anchor())); //points AWAY FROM new_vertex
-            arrangement->halfedges.push_back(new_edge);
-            std::shared_ptr<Halfedge> new_twin(new Halfedge(NULL, incoming->get_anchor())); //points TOWARDS new_vertex
-            arrangement->halfedges.push_back(new_twin);
+            auto new_edge = new Halfedge(new_vertex, incoming->get_anchor()); //points AWAY FROM new_vertex
+            arrangement.halfedges.push_back(new_edge);
+            auto new_twin = new Halfedge(NULL, incoming->get_anchor()); //points TOWARDS new_vertex
+            arrangement.halfedges.push_back(new_twin);
 
             //update halfedge pointers
             new_edge->set_twin(new_twin);
@@ -303,8 +303,8 @@ void ArrangementBuilder::build_interior(std::shared_ptr<Arrangement> arrangement
                 incoming->set_next(prev_incoming->get_twin());
                 incoming->get_next()->set_prev(incoming);
 
-                std::shared_ptr<Face> new_face(new Face(new_twin, arrangement->faces.size()));
-                arrangement->faces.push_back(new_face);
+                auto new_face = new Face(new_twin, arrangement.faces.size());
+                arrangement.faces.push_back(new_face);
 
                 new_twin->set_face(new_face);
                 prev_new_edge->set_face(new_face);
@@ -335,7 +335,7 @@ void ArrangementBuilder::build_interior(std::shared_ptr<Arrangement> arrangement
         //update lines vector: flip portion of vector [first_pos, last_pos]
         for (unsigned i = 0; i < (last_pos - first_pos + 1) / 2; i++) {
             //swap curves[first_pos + i] and curves[last_pos - i]
-            std::shared_ptr<Halfedge> temp = lines[first_pos + i];
+            auto temp = lines[first_pos + i];
             lines[first_pos + i] = lines[last_pos - i];
             lines[last_pos - i] = temp;
         }
@@ -343,29 +343,29 @@ void ArrangementBuilder::build_interior(std::shared_ptr<Arrangement> arrangement
         //find new intersections and add them to intersections queue
         if (first_pos > 0) //then consider lower intersection
         {
-            std::shared_ptr<Anchor> a = lines[first_pos - 1]->get_anchor();
-            std::shared_ptr<Anchor> b = lines[first_pos]->get_anchor();
+            auto a = lines[first_pos - 1]->get_anchor();
+            auto b = lines[first_pos]->get_anchor();
 
             if (considered_pairs.find(Anchor_pair(a, b)) == considered_pairs.end()
                 && considered_pairs.find(Anchor_pair(b, a)) == considered_pairs.end()) //then this pair has not yet been considered
             {
                 considered_pairs.insert(Anchor_pair(a, b));
                 if (a->comparable(*b)) //then the Anchors are (strongly) comparable, so we have found an intersection to store
-                    crossings.push(std::make_shared<Arrangement::Crossing>(a, b, arrangement));
+                    crossings.push(new Arrangement::Crossing(a, b, &arrangement));
             }
         }
 
         if (last_pos + 1 < lines.size()) //then consider upper intersection
         {
-            std::shared_ptr<Anchor> a = lines[last_pos]->get_anchor();
-            std::shared_ptr<Anchor> b = lines[last_pos + 1]->get_anchor();
+            auto a = lines[last_pos]->get_anchor();
+            auto b = lines[last_pos + 1]->get_anchor();
 
             if (considered_pairs.find(Anchor_pair(a, b)) == considered_pairs.end()
                 && considered_pairs.find(Anchor_pair(b, a)) == considered_pairs.end()) //then this pair has not yet been considered
             {
                 considered_pairs.insert(Anchor_pair(a, b));
                 if (a->comparable(*b)) //then the Anchors are (strongly) comparable, so we have found an intersection to store
-                    crossings.push(std::make_shared<Arrangement::Crossing>(a, b, arrangement));
+                    crossings.push(new Arrangement::Crossing(a, b, &arrangement));
             }
         }
 
@@ -382,7 +382,7 @@ void ArrangementBuilder::build_interior(std::shared_ptr<Arrangement> arrangement
         debug() << "PART 3: RIGHT EDGE OF THE ARRANGEMENT";
     }
 
-    std::shared_ptr<Halfedge> rightedge = arrangement->bottomright; //need a reference halfedge along the right side of the strip
+    auto rightedge = arrangement.bottomright; //need a reference halfedge along the right side of the strip
     unsigned cur_x = 0; //keep track of discrete x-coordinate of last Anchor whose line was connected to right edge (x-coordinate of Anchor is slope of line)
 
     //connect each line to the right edge of the arrangement (at x = INFTY)
@@ -390,28 +390,28 @@ void ArrangementBuilder::build_interior(std::shared_ptr<Arrangement> arrangement
     //    lines that have the same slope m are "tied together" at the same vertex, with coordinates (INFTY, Y)
     //    where Y = INFTY if m is positive, Y = -INFTY if m is negative, and Y = 0 if m is zero
     for (unsigned cur_pos = 0; cur_pos < lines.size(); cur_pos++) {
-        std::shared_ptr<Halfedge> incoming = lines[cur_pos];
-        std::shared_ptr<Anchor> cur_anchor = incoming->get_anchor();
+        auto incoming = lines[cur_pos];
+        auto cur_anchor = incoming->get_anchor();
 
         if (cur_anchor->get_x() > cur_x || cur_pos == 0) //then create a new vertex for this line
         {
             cur_x = cur_anchor->get_x();
 
             double Y = INFTY; //default, for lines with positive slope
-            if (arrangement->x_grades[cur_x] < 0)
+            if (arrangement.x_grades[cur_x] < 0)
                 Y = -1 * Y; //for lines with negative slope
-            else if (arrangement->x_grades[cur_x] == 0)
+            else if (arrangement.x_grades[cur_x] == 0)
                 Y = 0; //for horizontal lines
 
-            rightedge = arrangement->insert_vertex(rightedge, INFTY, Y);
+            rightedge = arrangement.insert_vertex(rightedge, INFTY, Y);
         } else //no new vertex required, but update previous entry for vertical-line queries
-            arrangement->vertical_line_query_list.pop_back();
+            arrangement.vertical_line_query_list.pop_back();
 
         //store Halfedge for vertical-line queries
-        arrangement->vertical_line_query_list.push_back(incoming->get_twin());
+        arrangement.vertical_line_query_list.push_back(incoming->get_twin());
 
         //connect current line to the most-recently-inserted vertex
-        std::shared_ptr<Vertex> cur_vertex = rightedge->get_origin();
+        auto cur_vertex = rightedge->get_origin();
         incoming->get_twin()->set_origin(cur_vertex);
 
         //update halfedge pointers
@@ -431,8 +431,8 @@ void ArrangementBuilder::build_interior(std::shared_ptr<Arrangement> arrangement
 //computes and stores the edge weight for each anchor line
 void ArrangementBuilder::find_edge_weights(Arrangement& arrangement, PersistenceUpdater& updater)
 {
-    std::vector<std::shared_ptr<Halfedge>> pathvec;
-    std::shared_ptr<Halfedge> cur_edge = arrangement.topright;
+    std::vector<Halfedge*> pathvec;
+    auto cur_edge = arrangement.topright;
 
     //find a path across all anchor lines
     while (cur_edge->get_twin() != arrangement.bottomright) //then there is another vertex to consider on the right edge
@@ -457,7 +457,7 @@ void ArrangementBuilder::find_edge_weights(Arrangement& arrangement, Persistence
 //finds a pseudo-optimal path through all 2-cells of the arrangement
 // path consists of a vector of Halfedges
 // at each step of the path, the Halfedge points to the Anchor being crossed and the 2-cell (Face) being entered
-void ArrangementBuilder::find_path(Arrangement& arrangement, std::vector<std::shared_ptr<Halfedge>>& pathvec)
+void ArrangementBuilder::find_path(Arrangement& arrangement, std::vector<Halfedge*>& pathvec)
 {
     // PART 1: BUILD THE DUAL GRAPH OF THE ARRANGEMENT
 
@@ -475,11 +475,11 @@ void ArrangementBuilder::find_path(Arrangement& arrangement, std::vector<std::sh
     //loop over all arrangement.faces
     for (unsigned i = 0; i < arrangement.faces.size(); i++) {
         //consider all neighbors of this arrangement.faces
-        std::shared_ptr<Halfedge> boundary = (arrangement.faces[i])->get_boundary();
-        std::shared_ptr<Halfedge> current = boundary;
+        auto boundary = (arrangement.faces[i])->get_boundary();
+        auto current = boundary;
         do {
             //find index of neighbor
-            std::shared_ptr<Face> neighbor = current->get_twin()->get_face();
+            auto neighbor = current->get_twin()->get_face();
             if (neighbor != NULL) {
                 unsigned long j = neighbor->id();
 
@@ -530,7 +530,7 @@ void ArrangementBuilder::find_path(Arrangement& arrangement, std::vector<std::sh
     }
 
     //make sure to start at the proper node (2-cell)
-    std::shared_ptr<Face> initial_cell = arrangement.topleft->get_twin()->get_face();
+    auto initial_cell = arrangement.topleft->get_twin()->get_face();
     unsigned long start = initial_cell->id();
 
     //store the children of each node (with initial_cell regarded as the root of the tree)
@@ -560,11 +560,14 @@ void ArrangementBuilder::find_path(Arrangement& arrangement, std::vector<std::sh
 //   children[i] is a vector of indexes of the children of node i, in decreasing order of branch weight
 //   (branch weight is total weight of all edges below a given node, plus weight of edge to parent node)
 // Output: vector pathvec contains a Halfedge pointer for each step of the path
-void ArrangementBuilder::find_subpath(Arrangement& arrangement, unsigned start_node, std::vector<std::vector<unsigned>>& children, std::vector<std::shared_ptr<Halfedge>>& pathvec)
+void ArrangementBuilder::find_subpath(Arrangement& arrangement,
+                                      unsigned start_node,
+                                      std::vector<std::vector<unsigned>>& children,
+                                      std::vector<Halfedge*>& pathvec)
 {
     std::stack<unsigned> nodes; // stack for nodes as we do DFS
     nodes.push(start_node); // push node onto the node stack
-    std::stack<std::shared_ptr<Halfedge>> backtrack; // stack for storing extra copy of std::shared_ptr<Halfedge>* so we don't have to recalculate when popping
+    std::stack<Halfedge*> backtrack; // stack for storing extra copy of std::shared_ptr<Halfedge>* so we don't have to recalculate when popping
     unsigned numDiscovered = 1, numNodes = children.size();
 
     while (numDiscovered != numNodes) // while we have not traversed the whole tree
@@ -577,7 +580,7 @@ void ArrangementBuilder::find_subpath(Arrangement& arrangement, unsigned start_n
             unsigned next_node = children[node].back();
             children[node].pop_back();
 
-            std::shared_ptr<Halfedge> cur_edge = (arrangement.faces[node])->get_boundary();
+            auto cur_edge = (arrangement.faces[node])->get_boundary();
             while (cur_edge->get_twin()->get_face() != arrangement.faces[next_node]) {
                 cur_edge = cur_edge->get_next();
 

--- a/dcel/arrangement_builder.h
+++ b/dcel/arrangement_builder.h
@@ -49,12 +49,12 @@ public:
 
 private:
     unsigned verbosity;
-    void build_interior(std::shared_ptr<Arrangement> arrangement);
+    void build_interior(Arrangement &arrangement);
     //builds the interior of DCEL arrangement using a version of the Bentley-Ottmann algorithm
     //precondition: all achors have been stored via find_anchors()
     void find_edge_weights(Arrangement& arrangement, PersistenceUpdater& updater);
-    void find_path(Arrangement& arrangement, std::vector<std::shared_ptr<Halfedge>>& pathvec);
-    void find_subpath(Arrangement& arrangement, unsigned cur_node, std::vector<std::vector<unsigned>>& adj, std::vector<std::shared_ptr<Halfedge>>& pathvec);
+    void find_path(Arrangement& arrangement, std::vector<Halfedge*>& pathvec);
+    void find_subpath(Arrangement& arrangement, unsigned cur_node, std::vector<std::vector<unsigned>>& adj, std::vector<Halfedge*>& pathvec);
 };
 
 #endif //RIVET_CONSOLE_MESH_BUILDER_H

--- a/dcel/arrangement_message.cpp
+++ b/dcel/arrangement_message.cpp
@@ -29,6 +29,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 template<typename T>
 struct Ptr_Compare {
+    bool operator()(const T* left, const T* right) const {
+        return &(*left) < &(*right);
+    }
     bool operator()(const std::shared_ptr<T> left, const std::shared_ptr<T> right) const {
         return &(*left) < &(*right);
     }
@@ -45,10 +48,10 @@ ArrangementMessage::ArrangementMessage(Arrangement const& arrangement)
     , anchors()
     , faces()
 {
-    std::map<std::shared_ptr<Face>, long, Ptr_Compare<Face>> face_map;
-    std::map<std::shared_ptr<Halfedge>, long, Ptr_Compare<Halfedge>> halfedge_map;
-    std::map<std::shared_ptr<Anchor>, long, Ptr_Compare<Anchor>> anchor_map;
-    std::map<std::shared_ptr<Vertex>, long, Ptr_Compare<Vertex>> vertex_map;
+    std::map<const Face*, long, Ptr_Compare<Face>> face_map;
+    std::map<const Halfedge*, long, Ptr_Compare<Halfedge>> halfedge_map;
+    std::map<const Anchor*, long, Ptr_Compare<Anchor>> anchor_map;
+    std::map<const Vertex*, long, Ptr_Compare<Vertex>> vertex_map;
     //Build maps
     long id_counter = 0;
     for(auto face : arrangement.faces) {
@@ -67,22 +70,22 @@ ArrangementMessage::ArrangementMessage(Arrangement const& arrangement)
         vertex_map.emplace(vertex, id_counter++);
     }
 
-    auto HID = [&halfedge_map](const std::shared_ptr<Halfedge> &ptr) {
+    auto HID = [&halfedge_map](const Halfedge* ptr) {
         auto it = halfedge_map.find(ptr);
         return it == halfedge_map.end() ? -1 : it->second;
     };
 
-    auto AID = [&anchor_map](const std::shared_ptr<Anchor> &ptr) {
+    auto AID = [&anchor_map](const Anchor* ptr) {
         auto it = anchor_map.find(ptr);
         return it == anchor_map.end() ? -1 : it->second;
     };
 
-    auto VID = [&vertex_map](const std::shared_ptr<Vertex> &ptr) {
+    auto VID = [&vertex_map](const Vertex* ptr) {
         auto it = vertex_map.find(ptr);
         return it == vertex_map.end() ? -1 : it->second;
     };
 
-    auto FID = [&face_map](const std::shared_ptr<Face> &ptr) {
+    auto FID = [&face_map](const Face* ptr) {
         return ptr == nullptr ? -1 : ptr->id();
     };
 
@@ -405,17 +408,17 @@ Arrangement ArrangementMessage::to_arrangement() const
     Arrangement arrangement;
     //First create all the objects
     for (auto vertex : vertices) {
-        arrangement.vertices.push_back(std::make_shared<::Vertex>(vertex.x, vertex.y));
+        arrangement.vertices.push_back(new ::Vertex(vertex.x, vertex.y));
     }
     for (size_t i = 0; i < faces.size(); i++) {
-        arrangement.faces.push_back(std::make_shared<::Face>(nullptr, i));
+        arrangement.faces.push_back(new ::Face(nullptr, i));
     }
     for (size_t i = 0; i < half_edges.size(); i++) {
-        arrangement.halfedges.push_back(std::make_shared<::Halfedge>());
+        arrangement.halfedges.push_back(new ::Halfedge());
     }
-    std::vector<std::shared_ptr<::Anchor>> temp_anchors; //For indexing, since arrangement.all_anchors is a set
+    std::vector<::Anchor*> temp_anchors; //For indexing, since arrangement.all_anchors is a set
     for (auto anchor : anchors) {
-        std::shared_ptr<::Anchor> ptr = std::make_shared<::Anchor>(anchor.x_coord, anchor.y_coord);
+        auto ptr = new ::Anchor(anchor.x_coord, anchor.y_coord);
         assert(anchor.x_coord == ptr->get_x());
         assert(anchor.y_coord == ptr->get_y());
         temp_anchors.push_back(ptr);
@@ -423,7 +426,7 @@ Arrangement ArrangementMessage::to_arrangement() const
 
 //    std::cout << "building anchors" << std::endl;
     arrangement.all_anchors.clear();
-    arrangement.all_anchors = std::set<std::shared_ptr<::Anchor>, PointerComparator<::Anchor, Anchor_LeftComparator>>(temp_anchors.begin(), temp_anchors.end());
+    arrangement.all_anchors = std::set<Anchor*, PointerComparator<::Anchor, Anchor_LeftComparator>>(temp_anchors.begin(), temp_anchors.end());
 
     assert(arrangement.all_anchors.size() == anchors.size());
 
@@ -487,9 +490,9 @@ Arrangement ArrangementMessage::to_arrangement() const
         ::Anchor& anchor = **it;
         ArrangementMessage::AnchorM ref = anchors[i];
         if (ref.dual_line != HalfedgeId::invalid()) {
-            std::shared_ptr<::Halfedge> edge = arrangement.halfedges[static_cast<long>(ref.dual_line)];
+            auto edge = arrangement.halfedges[static_cast<long>(ref.dual_line)];
             //TODO: why, oh why, should this reset be necessary?
-            anchor.get_line().reset();
+//            anchor.get_line().reset();
             anchor.set_line(edge);
         }
         if (ref.above_line != anchor.is_above()) {

--- a/dcel/arrangement_message.cpp
+++ b/dcel/arrangement_message.cpp
@@ -102,7 +102,6 @@ ArrangementMessage::ArrangementMessage(Arrangement const& arrangement)
             AnchorId(AID(half->get_anchor())) });
     }
     for (auto anchor : arrangement.all_anchors) {
-//        std::cerr << "Adding anchor: " << anchor->get_x() << ", " << anchor->get_y() << std::endl;
         anchors.push_back(AnchorM{
             anchor->get_x(),
             anchor->get_y(),
@@ -402,6 +401,7 @@ bool operator==(ArrangementMessage const& left, ArrangementMessage const& right)
 
 Arrangement ArrangementMessage::to_arrangement() const
 {
+//    std::cout << "constructing arrangement" << std::endl;
     Arrangement arrangement;
     //First create all the objects
     for (auto vertex : vertices) {
@@ -416,12 +416,12 @@ Arrangement ArrangementMessage::to_arrangement() const
     std::vector<std::shared_ptr<::Anchor>> temp_anchors; //For indexing, since arrangement.all_anchors is a set
     for (auto anchor : anchors) {
         std::shared_ptr<::Anchor> ptr = std::make_shared<::Anchor>(anchor.x_coord, anchor.y_coord);
-//        std::clog << "Adding anchor to arrangement: " << ptr->get_x() << ", " << ptr->get_y() << std::endl;
         assert(anchor.x_coord == ptr->get_x());
         assert(anchor.y_coord == ptr->get_y());
         temp_anchors.push_back(ptr);
     }
 
+//    std::cout << "building anchors" << std::endl;
     arrangement.all_anchors.clear();
     arrangement.all_anchors = std::set<std::shared_ptr<::Anchor>, PointerComparator<::Anchor, Anchor_LeftComparator>>(temp_anchors.begin(), temp_anchors.end());
 
@@ -429,17 +429,15 @@ Arrangement ArrangementMessage::to_arrangement() const
 
     auto it = arrangement.all_anchors.begin();
     for (size_t i = 0; i < anchors.size(); i++) {
-//        std::clog << "Checking: ";
-//        std::clog << anchors[i].x_coord << "-->" << temp_anchors[i]->get_x() << "-->" << (*it)->get_x() << " / ";
         assert(anchors[i].x_coord == temp_anchors[i]->get_x());
         assert(anchors[i].x_coord == (*it)->get_x());
-//        std::clog << anchors[i].y_coord << "-->" << temp_anchors[i]->get_y() << "-->" << (*it)->get_y() << std::endl;
         assert(anchors[i].y_coord == temp_anchors[i]->get_y());
         assert(anchors[i].y_coord == (*it)->get_y());
         ++it;
     }
 
     //Now populate all the pointers
+//    std::cout << "populating pointers" << std::endl;
 
     for (size_t i = 0; i < vertices.size(); i++) {
         if (vertices[i].incident_edge != HalfedgeId::invalid()) {
@@ -516,18 +514,15 @@ Arrangement ArrangementMessage::to_arrangement() const
 
     it = arrangement.all_anchors.begin();
     for (size_t i = 0; i < anchors.size(); i++) {
-//        std::clog << "Checking: ";
         assert(anchors[i].x_coord == temp_anchors[i]->get_x());
         assert(anchors[i].x_coord == (*it)->get_x());
-//        std::clog << anchors[i].x_coord << " ";
         assert(anchors[i].y_coord == temp_anchors[i]->get_y());
         assert(anchors[i].y_coord == (*it)->get_y());
-//        std::clog << anchors[i].y_coord << std::endl;
         assert(anchors[i].above_line == (*it)->is_above());
         assert(anchors[i].position == (*it)->get_position());
         ++it;
     }
-//    std::clog << "All anchors identical in to_arrangement" << std::endl;
+//    std::cout << "returning arrangement" << std::endl;
     return arrangement;
 }
 

--- a/dcel/arrangement_message.h
+++ b/dcel/arrangement_message.h
@@ -30,6 +30,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "type_tag.h"
 #include <boost/optional.hpp>
 #include <boost/serialization/split_member.hpp>
+#include <msgpack.hpp>
+#include "dcel/msgpack_adapters.h"
 
 class ArrangementMessage {
 
@@ -44,6 +46,8 @@ public:
         ar& x_grades& y_grades& x_exact & y_exact & half_edges& vertices
         & anchors& faces& topleft& topright& bottomleft& bottomright& vertical_line_query_list;
     }
+
+    MSGPACK_DEFINE(x_grades, y_grades, x_exact , y_exact , half_edges, vertices, anchors, faces, topleft, topright, bottomleft, bottomright, vertical_line_query_list);
 
     BarcodeTemplate get_barcode_template(double degrees, double offset);
 
@@ -93,6 +97,8 @@ private:
         {
             ar& x_coord& y_coord& dual_line& position& above_line& weight;
         }
+
+        MSGPACK_DEFINE(x_coord, y_coord, dual_line, position, above_line, weight);
     };
 
     friend bool operator==(AnchorM const& left, AnchorM const& right);
@@ -114,6 +120,8 @@ private:
         {
             ar& origin& twin& next& prev& face& anchor;
         }
+
+        MSGPACK_DEFINE(origin, twin, next, prev, face, anchor);
     };
 
     friend bool operator==(HalfedgeM const& left, HalfedgeM const& right);
@@ -127,6 +135,8 @@ private:
         {
             ar& boundary& dbc;
         }
+
+        MSGPACK_DEFINE(boundary, dbc);
     };
 
     friend bool operator==(FaceM const& left, FaceM const& right);
@@ -141,6 +151,7 @@ private:
         {
             ar& incident_edge& x& y;
         }
+        MSGPACK_DEFINE(incident_edge, x, y);
     };
 
     friend bool operator==(VertexM const& left, VertexM const& right);

--- a/dcel/arrangement_message.h
+++ b/dcel/arrangement_message.h
@@ -53,7 +53,7 @@ public:
 
     friend bool operator==(ArrangementMessage const& left, ArrangementMessage const& right);
 
-    Arrangement to_arrangement() const;
+    Arrangement* to_arrangement() const;
 
     bool is_empty() const;
 

--- a/dcel/barcode_template.h
+++ b/dcel/barcode_template.h
@@ -27,7 +27,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include <memory>
 #include <set>
 #include <vector>
-
+#include <msgpack.hpp>
 struct BarTemplate {
     unsigned begin; //index of TemplatePointsMatrixEntry of the equivalence class corresponding to the beginning of this bar
     unsigned end; //index of TemplatePointsMatrixEntry of the equivalence class corresponding to the end of this bar
@@ -45,6 +45,9 @@ struct BarTemplate {
     {
         ar& begin& end& multiplicity;
     }
+
+    MSGPACK_DEFINE(begin, end, multiplicity);
+
     friend bool operator==(BarTemplate const& left, BarTemplate const& right);
 };
 
@@ -79,6 +82,7 @@ public:
     {
         ar& bars;
     }
+    MSGPACK_DEFINE(bars);
     friend bool operator==(BarcodeTemplate const& left, BarcodeTemplate const& right);
 
 private:

--- a/dcel/dcel.cpp
+++ b/dcel/dcel.cpp
@@ -41,12 +41,12 @@ Vertex::Vertex()
 {
 }
 
-void Vertex::set_incident_edge(std::shared_ptr<Halfedge> edge)
+void Vertex::set_incident_edge(Halfedge* edge)
 {
     incident_edge = edge;
 }
 
-std::shared_ptr<Halfedge> Vertex::get_incident_edge()
+Halfedge* Vertex::get_incident_edge()
 {
     return incident_edge;
 }
@@ -75,7 +75,7 @@ bool Vertex::operator==(Vertex const& other)
 
 /*** implementation of class Halfedge ***/
 
-Halfedge::Halfedge(std::shared_ptr<Vertex> v, std::shared_ptr<Anchor> p)
+Halfedge::Halfedge(Vertex* v, Anchor* p)
     : origin(v)
     , twin(nullptr)
     , next(nullptr)
@@ -95,69 +95,69 @@ Halfedge::Halfedge()
 {
 }
 
-void Halfedge::set_twin(std::shared_ptr<Halfedge> e)
+void Halfedge::set_twin(Halfedge* e)
 {
     twin = e;
 }
 
-std::shared_ptr<Halfedge> Halfedge::get_twin() const
+Halfedge* Halfedge::get_twin() const
 {
     return twin;
 }
 
-void Halfedge::set_next(std::shared_ptr<Halfedge> e)
+void Halfedge::set_next(Halfedge* e)
 {
     next = e;
 }
 
-std::shared_ptr<Halfedge> Halfedge::get_next() const
+Halfedge* Halfedge::get_next() const
 {
     return next;
 }
 
-void Halfedge::set_prev(std::shared_ptr<Halfedge> e)
+void Halfedge::set_prev(Halfedge* e)
 {
     prev = e;
 }
 
-std::shared_ptr<Halfedge> Halfedge::get_prev() const
+Halfedge* Halfedge::get_prev() const
 {
     return prev;
 }
 
-void Halfedge::set_origin(std::shared_ptr<Vertex> v)
+void Halfedge::set_origin(Vertex* v)
 {
     origin = v;
 }
 
-std::shared_ptr<Vertex> Halfedge::get_origin() const
+Vertex* Halfedge::get_origin() const
 {
     return origin;
 }
 
-void Halfedge::set_face(std::shared_ptr<Face> f)
+void Halfedge::set_face(Face* f)
 {
     face = f;
 }
 
-std::shared_ptr<Face> Halfedge::get_face() const
+Face* Halfedge::get_face() const
 {
     return face;
 }
 
-void Halfedge::set_anchor(std::shared_ptr<Anchor> anchor)
+void Halfedge::set_anchor(Anchor* anchor)
 {
     this->anchor = anchor;
 }
 
-std::shared_ptr<Anchor> Halfedge::get_anchor() const
+Anchor* Halfedge::get_anchor() const
 {
     return anchor;
 }
 
 Debug& operator<<(Debug& qd, const Halfedge& e)
 {
-    std::shared_ptr<Halfedge> t = e.twin;
+    Halfedge* t = e.twin;
     qd << *(e.origin) << "--" << *(t->origin) << "; ";
     if (e.anchor == nullptr)
         qd << "Anchor null; ";
@@ -168,7 +168,7 @@ Debug& operator<<(Debug& qd, const Halfedge& e)
 
 /*** implementation of class Face ***/
 
-Face::Face(std::shared_ptr<Halfedge> e, unsigned long id)
+Face::Face(Halfedge* e, unsigned long id)
     : boundary(e)
     , visited(false)
 , identifier(id)
@@ -186,12 +186,12 @@ Face::~Face()
 {
 }
 
-void Face::set_boundary(std::shared_ptr<Halfedge> e)
+void Face::set_boundary(Halfedge* e)
 {
     boundary = e;
 }
 
-std::shared_ptr<Halfedge> Face::get_boundary()
+Halfedge* Face::get_boundary()
 {
     return boundary;
 }
@@ -218,8 +218,8 @@ void Face::mark_as_visited()
 
 Debug& operator<<(Debug& qd, const Face& f)
 {
-    std::shared_ptr<Halfedge> start = f.boundary;
-    std::shared_ptr<Halfedge> curr = start;
+    Halfedge* start = f.boundary;
+    Halfedge* curr = start;
     do {
         qd << *(curr->get_origin()) << "--";
         curr = curr->get_next();

--- a/dcel/dcel.h
+++ b/dcel/dcel.h
@@ -45,8 +45,8 @@ public:
     Vertex(double x_coord, double y_coord); //constructor, sets (x, y)-coordinates of the vertex
     Vertex(); //For serialization
 
-    void set_incident_edge(std::shared_ptr<Halfedge> edge); //set the incident edge
-    std::shared_ptr<Halfedge> get_incident_edge(); //get the incident edge
+    void set_incident_edge(Halfedge* edge); //set the incident edge
+    Halfedge* get_incident_edge(); //get the incident edge
 
     double get_x(); //get the x-coordinate
     double get_y(); //get the y-coordinate
@@ -59,7 +59,7 @@ public:
     void serialize(Archive& ar, const unsigned int version);
 
 private:
-    std::shared_ptr<Halfedge> incident_edge; //pointer to one edge incident to this vertex
+    Halfedge* incident_edge; //pointer to one edge incident to this vertex
     double x; //x-coordinate of this vertex
     double y; //y-coordinate of this vertex
 
@@ -70,26 +70,26 @@ class Anchor;
 
 class Halfedge {
 public:
-    Halfedge(std::shared_ptr<Vertex> v, std::shared_ptr<Anchor> p); //constructor, requires origin vertex as well as Anchor corresponding to this halfedge (Anchor never changes)
+    Halfedge(Vertex* v, Anchor* p); //constructor, requires origin vertex as well as Anchor corresponding to this halfedge (Anchor never changes)
     Halfedge(); //constructor for a null Halfedge
 
-    void set_twin(std::shared_ptr<Halfedge> e); //set the twin halfedge
-    std::shared_ptr<Halfedge> get_twin() const; //get the twin halfedge
+    void set_twin(Halfedge* e); //set the twin halfedge
+    Halfedge* get_twin() const; //get the twin halfedge
 
-    void set_next(std::shared_ptr<Halfedge> e); //set the next halfedge in the boundary of the face that this halfedge borders
-    std::shared_ptr<Halfedge> get_next() const; //get the next halfedge
+    void set_next(Halfedge* e); //set the next halfedge in the boundary of the face that this halfedge borders
+    Halfedge* get_next() const; //get the next halfedge
 
-    void set_prev(std::shared_ptr<Halfedge> e); //set the previous halfedge in the boundary of the face that this halfedge borders
-    std::shared_ptr<Halfedge> get_prev() const; //get the previous halfedge
+    void set_prev(Halfedge* e); //set the previous halfedge in the boundary of the face that this halfedge borders
+    Halfedge* get_prev() const; //get the previous halfedge
 
-    void set_origin(std::shared_ptr<Vertex> v); //set the origin vertex
-    std::shared_ptr<Vertex> get_origin() const; //get the origin vertex
+    void set_origin(Vertex* v); //set the origin vertex
+    Vertex* get_origin() const; //get the origin vertex
 
-    void set_face(std::shared_ptr<Face> f); //set the face that this halfedge borders
-    std::shared_ptr<Face> get_face() const; //get the face that this halfedge borders
+    void set_face(Face* f); //set the face that this halfedge borders
+    Face* get_face() const; //get the face that this halfedge borders
 
-    void set_anchor(std::shared_ptr<Anchor>); //set the Anchor
-    std::shared_ptr<Anchor> get_anchor() const; //get the Anchor
+    void set_anchor(Anchor*); //set the Anchor
+    Anchor* get_anchor() const; //get the Anchor
 
     friend Debug& operator<<(Debug& qd, const Halfedge& e); //for printing the halfedge
 
@@ -97,23 +97,23 @@ public:
     void serialize(Archive& ar, const unsigned int version);
 
 private:
-    std::shared_ptr<Vertex> origin; //pointer to the vertex from which this halfedge originates
-    std::shared_ptr<Halfedge> twin; //pointer to the halfedge that, together with this halfedge, make one edge
-    std::shared_ptr<Halfedge> next; //pointer to the next halfedge around the boundary of the face to the right of this halfedge
-    std::shared_ptr<Halfedge> prev; //pointer to the previous halfedge around the boundary of the face to the right of this halfedge
-    std::shared_ptr<Face> face; //pointer to the face to the right of this halfedge
-    std::shared_ptr<Anchor> anchor; //stores the coordinates of the anchor corresponding to this halfedge
+    Vertex* origin; //pointer to the vertex from which this halfedge originates
+    Halfedge* twin; //pointer to the halfedge that, together with this halfedge, make one edge
+    Halfedge* next; //pointer to the next halfedge around the boundary of the face to the right of this halfedge
+    Halfedge* prev; //pointer to the previous halfedge around the boundary of the face to the right of this halfedge
+    Face* face; //pointer to the face to the right of this halfedge
+    Anchor* anchor; //stores the coordinates of the anchor corresponding to this halfedge
 
 }; //end class Halfedge
 
 class Face {
 public:
-    Face(std::shared_ptr<Halfedge> e, unsigned long id); //constructor: requires pointer to a boundary halfedge
+    Face(Halfedge* e, unsigned long id); //constructor: requires pointer to a boundary halfedge
     Face(); // For serialization
     ~Face(); //destructor: destroys barcode template
 
-    void set_boundary(std::shared_ptr<Halfedge> e); //set the pointer to a halfedge on the boundary of this face
-    std::shared_ptr<Halfedge> get_boundary(); //get the (pointer to the) boundary halfedge
+    void set_boundary(Halfedge* e); //set the pointer to a halfedge on the boundary of this face
+    Halfedge* get_boundary(); //get the (pointer to the) boundary halfedge
 
     BarcodeTemplate& get_barcode(); //returns a reference to the barcode template stored in this cell
     void set_barcode(const BarcodeTemplate& bt); //stores (a copy of) the specified barcode template in this cell
@@ -129,7 +129,7 @@ public:
     unsigned long id() const;
 
 private:
-    std::shared_ptr<Halfedge> boundary; //pointer to one halfedge in the boundary of this cell
+    Halfedge* boundary; //pointer to one halfedge in the boundary of this cell
     BarcodeTemplate dbc; //barcode template stored in this cell
     bool visited; //initially false, set to true after this cell has been visited in the vineyard-update process (so that we can distinguish a cell with an empty barcode from an unvisited cell)
     unsigned long identifier; // Arrangement-specific ID for this face

--- a/dcel/dcel.h
+++ b/dcel/dcel.h
@@ -151,6 +151,7 @@ struct TemplatePointsMessage {
     {
         ar& x_label& y_label& template_points& homology_dimensions& x_exact& y_exact;
     }
+    MSGPACK_DEFINE(x_label, y_label, template_points, homology_dimensions, x_exact, y_exact);
 };
 
 #endif // __DCEL_H__

--- a/dcel/msgpack_adapters.h
+++ b/dcel/msgpack_adapters.h
@@ -12,12 +12,9 @@ namespace msgpack {
             template<>
             struct as<exact> {
                 exact operator()(msgpack::object const& o) const {
-                    throw std::runtime_error("not implemented");
-//                    if (o.type != msgpack::type::ARRAY) throw msgpack::type_error();
-//                    if (o.via.array.size != 2) throw msgpack::type_error();
-//                    boost::multiprecision::cpp_int num = o.via.array.ptr[0].as<boost::multiprecision::cpp_int>();
-//                    boost::multiprecision::cpp_int denom = o.via.array.ptr[1].as<boost::multiprecision::cpp_int>();
-//                    return exact(num, denom);
+                    std::string buf;
+                    o.convert(buf);
+                    return exact(buf);
                 }
             };
             template<>

--- a/dcel/msgpack_adapters.h
+++ b/dcel/msgpack_adapters.h
@@ -83,7 +83,6 @@ namespace msgpack {
                     std::vector<unsigned> dims = o.via.array.ptr[0].convert();
                     std::vector<unsigned> data = o.via.array.ptr[1].convert();
                     auto size = extents[dims[0]][dims[1]];
-                    std::cerr << std::endl;
                     mat.resize(size);
                     std::memcpy(mat.origin(), data.data(), data.size() * sizeof(unsigned));
                     return o;

--- a/dcel/msgpack_adapters.h
+++ b/dcel/msgpack_adapters.h
@@ -1,0 +1,126 @@
+#include <msgpack.hpp>
+#include "numerics.h"
+
+#ifndef MSGPACK_ADAPTERS_H
+#define MSGPACK_ADAPTERS_H
+
+// User defined class template specialization
+namespace msgpack {
+    MSGPACK_API_VERSION_NAMESPACE(MSGPACK_DEFAULT_API_NS) {
+        namespace adaptor {
+
+            template<>
+            struct as<exact> {
+                exact operator()(msgpack::object const& o) const {
+                    throw std::runtime_error("not implemented");
+//                    if (o.type != msgpack::type::ARRAY) throw msgpack::type_error();
+//                    if (o.via.array.size != 2) throw msgpack::type_error();
+//                    boost::multiprecision::cpp_int num = o.via.array.ptr[0].as<boost::multiprecision::cpp_int>();
+//                    boost::multiprecision::cpp_int denom = o.via.array.ptr[1].as<boost::multiprecision::cpp_int>();
+//                    return exact(num, denom);
+                }
+            };
+            template<>
+            struct pack<exact> {
+                template <typename Stream>
+                msgpack::packer<Stream>& operator()(msgpack::packer<Stream>& o, exact const& mat) const {
+                    std::ostringstream oss;
+                    oss << mat;
+                    std::string s = oss.str();
+                    o.pack(s);
+                    return o;
+                }
+            };
+
+            template<>
+            struct as<boost::multiprecision::cpp_int> {
+                boost::multiprecision::cpp_int operator()(msgpack::object const& o) const {
+                    if (o.type != msgpack::type::STR) throw msgpack::type_error();
+                    std::string s(o.via.str.ptr, o.via.str.size);
+                    return boost::multiprecision::cpp_int(s);
+                }
+            };
+            template<>
+            struct convert<boost::multiprecision::cpp_int> {
+                msgpack::object const& operator()(msgpack::object const& o, boost::multiprecision::cpp_int &num) const {
+                    if (o.type != msgpack::type::STR) throw msgpack::type_error();
+                    std::string s(o.via.str.ptr, o.via.str.size);
+                    num = boost::multiprecision::cpp_int(s);
+                    return o;
+                }
+            };
+            template<>
+            struct pack<boost::multiprecision::cpp_int> {
+                template <typename Stream>
+                msgpack::packer<Stream>& operator()(msgpack::packer<Stream>& o, boost::multiprecision::cpp_int const& mat) const {
+                    std::string s = mat.str();
+                    o.pack_str(s.length());
+                    o.pack_str_body(s.data(), s.length());
+                    return o;
+                }
+            };
+
+            template<>
+            struct as<unsigned_matrix> {
+                unsigned_matrix operator()(msgpack::object const& o) const {
+                    if (o.type != msgpack::type::ARRAY) throw msgpack::type_error();
+                    if (o.via.array.size != 2) throw msgpack::type_error();
+                    unsigned_matrix mat;
+                    unsigned_matrix::extent_gen extents;
+                    std::vector<unsigned> dims = o.via.array.ptr[0].as<std::vector<unsigned >>();
+                    std::vector<unsigned> data = o.via.array.ptr[1].as<std::vector<unsigned>>();
+                    auto size = extents[dims[0]][dims[1]];
+                    std::cerr << std::endl;
+                    mat.resize(size);
+                    std::memcpy(mat.origin(), data.data(), data.size() * sizeof(unsigned));
+                    return mat;
+                }
+            };
+
+            template<>
+            struct convert<unsigned_matrix> {
+                msgpack::object const& operator()(msgpack::object const& o, unsigned_matrix& mat) const {
+                    if(o.type != type::ARRAY) { throw type_error(); }
+                    if(o.via.array.size != 2) { throw type_error(); }
+                    unsigned_matrix::extent_gen extents;
+                    std::vector<unsigned> dims = o.via.array.ptr[0].convert();
+                    std::vector<unsigned> data = o.via.array.ptr[1].convert();
+                    auto size = extents[dims[0]][dims[1]];
+                    std::cerr << std::endl;
+                    mat.resize(size);
+                    std::memcpy(mat.origin(), data.data(), data.size() * sizeof(unsigned));
+                    return o;
+                }
+            };
+
+            template<>
+            struct pack<unsigned_matrix> {
+                template <typename Stream>
+                msgpack::packer<Stream>& operator()(msgpack::packer<Stream>& o, unsigned_matrix const& mat) const {
+                    std::vector<unsigned> dims(mat.shape(), mat.shape() + mat.num_dimensions());
+                    std::vector<unsigned> data(mat.origin(), mat.origin() + mat.num_elements());
+                    o.pack_array(2);
+                    o.pack(dims);
+                    o.pack(data);
+                    return o;
+                }
+            };
+
+            template <>
+            struct object_with_zone<unsigned_matrix> {
+                void operator()(msgpack::object::with_zone& o, unsigned_matrix const& mat) const {
+                    o.type = type::ARRAY;
+                    o.via.array.size = 2;
+                    std::vector<unsigned> dims(mat.shape(), mat.shape() + mat.num_dimensions());
+                    std::vector<unsigned> data(mat.origin(), mat.origin() + mat.num_elements());
+                    o.via.array.ptr = static_cast<msgpack::object*>(
+                            o.zone.allocate_align(sizeof(msgpack::object) * o.via.array.size, MSGPACK_ZONE_ALIGNOF(msgpack::object)));
+                    o.via.array.ptr[0] = msgpack::object(dims, o.zone);
+                    o.via.array.ptr[1] = msgpack::object(data, o.zone);
+                }
+            };
+
+        } // namespace adaptor
+    } // MSGPACK_API_VERSION_NAMESPACE(MSGPACK_DEFAULT_API_NS)
+} // namespace msgpack
+#endif

--- a/dcel/serialization.h
+++ b/dcel/serialization.h
@@ -42,6 +42,10 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "math/template_points_matrix.h"
 #include "numerics.h"
 #include "type_tag.h"
+#include <msgpack.hpp>
+#include "msgpack_external.h"
+
+
 //namespace boost {
 //    namespace multiprecision {
 //        template<class Archive>
@@ -114,6 +118,41 @@ void save(Archive& ar, unsigned_matrix const& mat, const unsigned int& /*version
     ar& dims& data;
 }
 
+//        inline unsigned_matrix& operator>> (::msgpack::object o, unsigned_matrix& v)
+//        {
+//            std::vector<unsigned> dims;
+//            std::vector<unsigned> data;
+//            throw std::runtime_error("not implemented");
+//            ar& dims& data;
+//            unsigned_matrix::extent_gen extents;
+//            auto size = extents[dims[0]][dims[1]];
+//            //    std::cerr << "Data: ";
+//            //    for (auto d : data) {
+//            //        std::cerr << d << " ";
+//            //    }
+//            std::cerr << std::endl;
+//            mat.resize(size);
+//            std::memcpy(mat.origin(), data.data(), data.size() * sizeof(unsigned));
+//            if(o.type != type::ARRAY) { throw type_error(); }
+//            if(o.via.array.size != 3) { throw type_error(); }
+//            o.via.array.ptr[0].convert(&v.X);
+//            o.via.array.ptr[1].convert(&v.Y);
+//            o.via.array.ptr[2].convert(&v.Z);
+//            return v;
+//        }
+
+//        template <typename Stream>
+//        inline ::msgpack::packer<Stream>& operator<< (::msgpack::packer<Stream>& o, const unsigned_matrix& mat)
+//        {
+//            std::vector<unsigned> dims(mat.shape(), mat.shape() + mat.num_dimensions());
+//            std::vector<unsigned> data(mat.origin(), mat.origin() + mat.num_elements());
+//            o.pack(dims);
+//            o.pack(data);
+//            return o;
+//        }
+
+
+
 template <class Archive>
 void load(Archive& ar, unsigned_matrix& mat, const unsigned int& /*version*/)
 {
@@ -131,5 +170,7 @@ void load(Archive& ar, unsigned_matrix& mat, const unsigned int& /*version*/)
     std::memcpy(mat.origin(), data.data(), data.size() * sizeof(unsigned));
 }
 }
+
+
 
 #endif //RIVET_CONSOLE_SERIALIZATION_H

--- a/dcel/serialization.h
+++ b/dcel/serialization.h
@@ -43,7 +43,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "numerics.h"
 #include "type_tag.h"
 #include <msgpack.hpp>
-#include "msgpack_external.h"
 
 
 //namespace boost {
@@ -64,8 +63,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 //    }
 //}
 
-BOOST_CLASS_EXPORT(BarcodeTemplate)
-BOOST_CLASS_EXPORT(BarTemplate)
 
 template <class Archive>
 void Vertex::serialize(Archive& ar, const unsigned int /*version*/)

--- a/interface/c_api.cpp
+++ b/interface/c_api.cpp
@@ -1,0 +1,65 @@
+//
+// Created by Bryn Keller on 11/16/17.
+//
+
+
+#include "c_api.h"
+#include <msgpack.hpp>
+#include <dcel/dcel.h>
+#include <dcel/arrangement_message.h>
+#include <computation.h>
+#include <api.h>
+#include <vector>
+#include "dcel/msgpack_adapters.h"
+#include "input_parameters.h"
+
+
+
+extern "C"
+BarCodesResult* barcodes_from_bytes(const char* bytes,
+                                    size_t length,
+                                    double* angles,
+                                    double* offsets,
+                                    size_t query_length
+) {
+    try {
+        std::istringstream buf(std::string(bytes, length));
+        auto computation = from_istream(buf);
+
+        std::vector<std::pair<double, double>> pos;
+        for (size_t i = 0; i < query_length; i++) {
+            pos.emplace_back(angles[i], offsets[i]);
+        }
+        auto query_results = query_barcodes(*computation, pos);
+        auto barcodes = new BarCode[query_results.size()];
+        for (size_t i = 0; i < query_length; i++) {
+            auto query_barcode = std::shared_ptr<Barcode>(std::move(query_results[i]));
+            barcodes[i].bars = new Bar[query_barcode->size()];
+            auto it = query_barcode->begin();
+            for (size_t b = 0; b < query_barcode->size(); b++) {
+                barcodes[i].bars[b] = Bar{it->birth, it->death, it->multiplicity};
+                it++;
+            }
+            barcodes[i].length = query_barcode->size();
+            barcodes[i].angle = angles[i];
+            barcodes[i].offset = offsets[i];
+        }
+        auto result = new BarCodesResult{barcodes, query_results.size()};
+        return result;
+    } catch (std::exception &e) {
+        std::cerr << "RIVET error: " << e.what() << std::endl;
+        return nullptr;
+    }
+}
+
+extern "C"
+void free_barcodes_result(BarCodesResult *result) {
+    for (size_t bc = 0; bc < result->length; bc++) {
+        auto bcp = result->barcodes[bc];
+        delete[] bcp.bars;
+    }
+    delete[] result->barcodes;
+    delete result;
+}
+
+

--- a/interface/c_api.h
+++ b/interface/c_api.h
@@ -1,0 +1,57 @@
+//
+// Created by Bryn Keller on 11/16/17.
+//
+
+#ifndef RIVET_CONSOLE_C_API_H
+#define RIVET_CONSOLE_C_API_H
+
+#include <cstdlib>
+
+extern "C" {
+
+//typedef struct {
+//    unsigned dimensions;
+//    double max_distance;
+//    double * data;
+//    char * param1_name;
+//    char * param2_name;
+//} PointCloud;
+//
+
+typedef struct {
+    void * input_params;
+    void * template_points;
+    void * arrangement;
+} Computed;
+
+typedef struct {
+    double birth;
+    double death;
+    unsigned multiplicity;
+} Bar;
+
+typedef struct {
+    Bar* bars;
+    size_t length;
+    double angle;
+    double offset;
+} BarCode;
+
+typedef struct {
+    BarCode* barcodes;
+    size_t length;
+} BarCodesResult;
+
+//Computed* compute_arrangement_from_point_cloud(PointCloud);
+BarCodesResult* barcodes_from_bytes(const char* bytes,
+                                    size_t length,
+                                    double* offsets,
+                                    double* angles,
+                                    size_t query_length
+                                    );
+
+void free_barcodes_result(BarCodesResult *result);
+
+}
+
+#endif //RIVET_CONSOLE_C_API_H

--- a/interface/c_api.h
+++ b/interface/c_api.h
@@ -42,13 +42,28 @@ typedef struct {
     size_t length;
 } BarCodesResult;
 
+typedef struct {
+    double x_low;
+    double y_low;
+    double x_high;
+    double y_high;
+} ArrangementBounds;
+
+struct rivet_comp;
+typedef rivet_comp RivetComputation;
+
+RivetComputation * read_rivet_computation(const char* bytes, size_t length);
+
 //Computed* compute_arrangement_from_point_cloud(PointCloud);
-BarCodesResult* barcodes_from_bytes(const char* bytes,
-                                    size_t length,
+BarCodesResult* barcodes_from_computation(RivetComputation* rivet_computation,
                                     double* offsets,
                                     double* angles,
                                     size_t query_length
                                     );
+
+ArrangementBounds bounds_from_computation(RivetComputation* rivet_computation);
+
+void free_rivet_computation(RivetComputation * rivet_computation);
 
 void free_barcodes_result(BarCodesResult *result);
 

--- a/interface/configuredialog.h
+++ b/interface/configuredialog.h
@@ -23,6 +23,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 struct ConfigParameters;
 
+#include "api.h"
 #include "input_parameters.h"
 
 #include <QColor>

--- a/interface/input_manager.cpp
+++ b/interface/input_manager.cpp
@@ -176,7 +176,7 @@ std::unique_ptr<InputData> InputManager::read_point_cloud(std::ifstream& stream,
 {
     //TODO : switch to YAML or JSON input or switch to proper parser generator or combinators
     FileInputReader reader(stream);
-    auto data = std::make_unique<InputData>();
+    auto data = std::unique_ptr<InputData>(new InputData());
     if (verbosity >= 6) {
         debug() << "InputManager: Found a point cloud file.";
     }

--- a/interface/input_manager.h
+++ b/interface/input_manager.h
@@ -33,7 +33,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "math/template_points_matrix.h"
 #include "progress.h"
 #include <boost/multiprecision/cpp_int.hpp>
-typedef boost::multiprecision::cpp_rational exact;
 
 #include "numerics.h"
 #include <fstream>

--- a/interface/input_parameters.h
+++ b/interface/input_parameters.h
@@ -42,6 +42,8 @@ struct InputParameters {
     {
         ar& fileName& shortName& outputFile& dim& x_bins& y_bins& verbosity& x_label& y_label& outputFormat;
     }
+    MSGPACK_DEFINE(fileName, shortName, outputFile, dim, x_bins, y_bins, verbosity, x_label, y_label, outputFormat);
+
 };
 
 #endif // INPUT_PARAMETERS_H

--- a/main.cpp
+++ b/main.cpp
@@ -18,6 +18,7 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 **********************************************************************/
 
+#include "api.h"
 #include "interface/input_parameters.h"
 #include "visualizationwindow.h"
 

--- a/math/persistence_updater.h
+++ b/math/persistence_updater.h
@@ -52,11 +52,11 @@ public:
     //PersistenceUpdater(Arrangement& m, std::vector<TemplatePoint>& xi_pts); //constructor for when we load the pre-computed barcode templates from a RIVET data file
 
     //functions to compute and store barcode templates in each 2-cell of the arrangement
-    void store_barcodes_with_reset(std::vector<std::shared_ptr<Halfedge>>& path, Progress& progress); //hybrid approach -- for expensive crossings, resets the matrices and does a standard persistence calculation
-    void store_barcodes_quicksort(std::vector<std::shared_ptr<Halfedge>>& path); ///TODO -- for expensive crossings, rearranges columns via quicksort and fixes the RU-decomposition globally
+    void store_barcodes_with_reset(std::vector<Halfedge*>& path, Progress& progress); //hybrid approach -- for expensive crossings, resets the matrices and does a standard persistence calculation
+    void store_barcodes_quicksort(std::vector<Halfedge*>& path); ///TODO -- for expensive crossings, rearranges columns via quicksort and fixes the RU-decomposition globally
 
     //function to set the "edge weights" for each anchor line
-    void set_anchor_weights(std::vector<std::shared_ptr<Halfedge>>& path);
+    void set_anchor_weights(std::vector<Halfedge*>& path);
 
     //function to clear the levelset lists -- e.g., following the edge-weight calculation
     void clear_levelsets();
@@ -72,8 +72,8 @@ private:
 
     TemplatePointsMatrix template_points_matrix; //sparse matrix to hold xi support points -- used for finding anchors (to build the arrangement) and tracking simplices during the vineyard updates (when computing barcodes to store in the arrangement)
 
-    std::map<unsigned, std::shared_ptr<TemplatePointsMatrixEntry>> lift_low; //map from "low" columns to xiMatrixEntrys
-    std::map<unsigned, std::shared_ptr<TemplatePointsMatrixEntry>> lift_high; //map from "high" columns to xiMatrixEntrys
+    std::map<unsigned, TemplatePointsMatrixEntry*> lift_low; //map from "low" columns to xiMatrixEntrys
+    std::map<unsigned, TemplatePointsMatrixEntry*> lift_high; //map from "high" columns to xiMatrixEntrys
 
     MapMatrix_Perm* R_low; //boundary matrix for "low" simplices
     MapMatrix_Perm* R_high; //boundary matrix for "high" simplices
@@ -107,26 +107,26 @@ private:
     unsigned build_simplex_order(IndexMatrix* ind, bool low, std::vector<int>& simplex_order);
 
     //counts the number of transpositions that will happen if we cross an anchor and do vineyeard-updates
-    unsigned long count_transpositions(std::shared_ptr<TemplatePointsMatrixEntry> at_anchor, bool from_below);
+    unsigned long count_transpositions(TemplatePointsMatrixEntry* at_anchor, bool from_below);
 
     //counts the number of transpositions that result from separations; used in the above function
-    void count_transpositions_from_separations(std::shared_ptr<TemplatePointsMatrixEntry> greater, std::shared_ptr<TemplatePointsMatrixEntry> lesser, bool horiz, bool low, unsigned long& count_trans, unsigned& count_lesser);
+    void count_transpositions_from_separations(TemplatePointsMatrixEntry* greater, TemplatePointsMatrixEntry* lesser, bool horiz, bool low, unsigned long& count_trans, unsigned& count_lesser);
 
     //moves grades associated with TemplatePointsMatrixEntry greater, that come before TemplatePointsMatrixEntry lesser in R^2, so that they become associated with lesser
     //   horiz is true iff greater and lesser are on the same horizontal line (i.e., they share the same y-coordinate)
     //   returns a count of the number transpositions performed
-    unsigned long split_grade_lists(std::shared_ptr<TemplatePointsMatrixEntry> greater, std::shared_ptr<TemplatePointsMatrixEntry> lesser, bool horiz);
+    unsigned long split_grade_lists(TemplatePointsMatrixEntry* greater, TemplatePointsMatrixEntry* lesser, bool horiz);
 
     //splits grade lists and updates the permutation vectors, but does NOT do vineyard updates
-    void split_grade_lists_no_vineyards(std::shared_ptr<TemplatePointsMatrixEntry> greater, std::shared_ptr<TemplatePointsMatrixEntry> lesser, bool horiz);
+    void split_grade_lists_no_vineyards(TemplatePointsMatrixEntry* greater, TemplatePointsMatrixEntry* lesser, bool horiz);
 
     //moves all grades associated with TemplatePointsMatrixEntry lesser so that they become associated with TemplatePointsMatrixEntry greater
-    void merge_grade_lists(std::shared_ptr<TemplatePointsMatrixEntry> greater, std::shared_ptr<TemplatePointsMatrixEntry> lesser);
+    void merge_grade_lists(TemplatePointsMatrixEntry* greater, TemplatePointsMatrixEntry* lesser);
 
-    //moves columns from an equivalence class given by std::shared_ptr<TemplatePointsMatrixEntry> first to their new positions after or among the columns in the equivalence class given by std::shared_ptr<TemplatePointsMatrixEntry> second
+    //moves columns from an equivalence class given by TemplatePointsMatrixEntry* first to their new positions after or among the columns in the equivalence class given by TemplatePointsMatrixEntry* second
     //  the boolean argument indicates whether an anchor is being crossed from below (or from above)
     //  returns a count of the number of transpositions performed
-    unsigned long move_columns(std::shared_ptr<TemplatePointsMatrixEntry> first, std::shared_ptr<TemplatePointsMatrixEntry> second, bool from_below);
+    unsigned long move_columns(TemplatePointsMatrixEntry* first, TemplatePointsMatrixEntry* second, bool from_below);
 
     //moves a block of n columns, the rightmost of which is column s, to a new position following column t (NOTE: assumes s <= t)
     //  returns a count of the number of transpositions performed
@@ -138,26 +138,26 @@ private:
     void vineyard_update_high(unsigned a);
 
     //swaps two blocks of columns by updating the total order on columns, then rebuilding the matrices and computing a new RU-decomposition
-    void update_order_and_reset_matrices(std::shared_ptr<TemplatePointsMatrixEntry> first, std::shared_ptr<TemplatePointsMatrixEntry> second, bool from_below, MapMatrix_Perm* RL_initial, MapMatrix_Perm* RH_initial);
+    void update_order_and_reset_matrices(TemplatePointsMatrixEntry* first, TemplatePointsMatrixEntry* second, bool from_below, MapMatrix_Perm* RL_initial, MapMatrix_Perm* RH_initial);
 
     //updates the total order on columns, rebuilds the matrices, and computing a new RU-decomposition for a NON-STRICT anchor
     void update_order_and_reset_matrices(MapMatrix_Perm* RL_initial, MapMatrix_Perm* RH_initial);
 
     //swaps two blocks of simplices in the total order, and counts switches and separations
-    void count_switches_and_separations(std::shared_ptr<TemplatePointsMatrixEntry> at_anchor, bool from_below, unsigned long& switches, unsigned long& seps);
+    void count_switches_and_separations(TemplatePointsMatrixEntry* at_anchor, bool from_below, unsigned long& switches, unsigned long& seps);
 
     //used by the previous function to split grade lists at each anchor crossing
-    void do_separations(std::shared_ptr<TemplatePointsMatrixEntry> greater, std::shared_ptr<TemplatePointsMatrixEntry> lesser, bool horiz);
+    void do_separations(TemplatePointsMatrixEntry* greater, TemplatePointsMatrixEntry* lesser, bool horiz);
 
     //removes entries corresponding to an TemplatePointsMatrixEntry from lift_low and lift_high
-    void remove_lift_entries(std::shared_ptr<TemplatePointsMatrixEntry> entry);
+    void remove_lift_entries(TemplatePointsMatrixEntry* entry);
 
     //creates the appropriate entries in lift_low and lift_high for an TemplatePointsMatrixEntry with nonempty sets of "low" or "high" simplices
-    void add_lift_entries(std::shared_ptr<TemplatePointsMatrixEntry> entry);
+    void add_lift_entries(TemplatePointsMatrixEntry* entry);
 
     //stores a barcode template in a 2-cell of the arrangement
     ///TODO: IMPROVE THIS -- track most recent barcode at the simplicial level and re-examine only the necessary columns!!!
-    void store_barcode_template(std::shared_ptr<Face> cell);
+    void store_barcode_template(Face* cell);
 
     //chooses an initial threshold by timing vineyard updates corresponding to random transpositions
     void choose_initial_threshold(unsigned decomp_time, unsigned long & num_trans, unsigned & trans_time, unsigned long & threshold);

--- a/math/template_point.h
+++ b/math/template_point.h
@@ -21,6 +21,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #ifndef TEMPLATE_POINT_H
 #define TEMPLATE_POINT_H
 
+#include <msgpack.hpp>
+#include "dcel/msgpack_adapters.h"
+
 //class to store xi points, to help send data from the Arrangement to the VisualizationWindow
 class TemplatePoint {
 public:
@@ -37,6 +40,7 @@ public:
     {
         archive& x& y& zero& one& two;
     }
+    MSGPACK_DEFINE(x, y, zero, one, two);
 };
 
 #endif // TEMPLATE_POINT_H

--- a/math/template_points_matrix.cpp
+++ b/math/template_points_matrix.cpp
@@ -46,7 +46,7 @@ TemplatePointsMatrixEntry::TemplatePointsMatrixEntry()
 }
 
 //regular constructor
-TemplatePointsMatrixEntry::TemplatePointsMatrixEntry(unsigned x, unsigned y, unsigned i, std::shared_ptr<TemplatePointsMatrixEntry> d, std::shared_ptr<TemplatePointsMatrixEntry> l)
+TemplatePointsMatrixEntry::TemplatePointsMatrixEntry(unsigned x, unsigned y, unsigned i, TemplatePointsMatrixEntry* d, TemplatePointsMatrixEntry* l)
     : x(x)
     , y(y)
     , index(i)
@@ -77,16 +77,16 @@ TemplatePointsMatrixEntry::TemplatePointsMatrixEntry(unsigned x, unsigned y)
 void TemplatePointsMatrixEntry::add_multigrade(unsigned x, unsigned y, unsigned num_cols, int index, bool low)
 {
     if (low) {
-        low_simplices.push_back(std::make_shared<Multigrade>(x, y, num_cols, index));
+        low_simplices.push_back(new Multigrade(x, y, num_cols, index));
         low_count += num_cols;
     } else {
-        high_simplices.push_back(std::make_shared<Multigrade>(x, y, num_cols, index));
+        high_simplices.push_back(new Multigrade(x, y, num_cols, index));
         high_count += num_cols;
     }
 }
 
 //inserts a Multigrade at the beginning of the list for the given dimension
-void TemplatePointsMatrixEntry::insert_multigrade(std::shared_ptr<Multigrade> mg, bool low)
+void TemplatePointsMatrixEntry::insert_multigrade(Multigrade* mg, bool low)
 {
     if (low)
         low_simplices.push_back(mg);
@@ -132,11 +132,11 @@ TemplatePointsMatrix::TemplatePointsMatrix(unsigned width, unsigned height)
 //  also finds anchors, which are stored in the matrix and in the vector xi_pts
 //  precondition: xi_pts contains the support points in lexicographical order
 //  Runtime complexity of this function is O(n_x * n_y). We can probably do better, but it probably doesn't matter.
-std::vector<std::shared_ptr<TemplatePointsMatrixEntry>> TemplatePointsMatrix::fill_and_find_anchors(std::vector<TemplatePoint>& xi_pts)
+std::vector<TemplatePointsMatrixEntry*> TemplatePointsMatrix::fill_and_find_anchors(std::vector<TemplatePoint>& xi_pts)
 {
     unsigned next_xi_pt = 0; //tracks the index of the next xi support point to insert
 
-    std::vector<std::shared_ptr<TemplatePointsMatrixEntry>> matrix_entries;
+    std::vector<TemplatePointsMatrixEntry*> matrix_entries;
 
     //loop over all grades in lexicographical order
     for (unsigned i = 0; i < columns.size(); i++) {
@@ -168,7 +168,7 @@ std::vector<std::shared_ptr<TemplatePointsMatrixEntry>> TemplatePointsMatrix::fi
             }
 
             //create a new TemplatePointsMatrixEntry
-            std::shared_ptr<TemplatePointsMatrixEntry> new_entry(new TemplatePointsMatrixEntry(i, j, insertion_point, columns[i], rows[j]));
+            TemplatePointsMatrixEntry* new_entry(new TemplatePointsMatrixEntry(i, j, insertion_point, columns[i], rows[j]));
             columns[i] = new_entry;
             rows[j] = new_entry;
 
@@ -181,13 +181,13 @@ std::vector<std::shared_ptr<TemplatePointsMatrixEntry>> TemplatePointsMatrix::fi
 } //end fill_and_find_anchors()
 
 //gets a pointer to the rightmost entry in row r; returns NULL if row r is empty
-std::shared_ptr<TemplatePointsMatrixEntry> TemplatePointsMatrix::get_row(unsigned r)
+TemplatePointsMatrixEntry* TemplatePointsMatrix::get_row(unsigned r)
 {
     return rows[r];
 }
 
 //gets a pointer to the top entry in column c; returns NULL if column c is empty
-std::shared_ptr<TemplatePointsMatrixEntry> TemplatePointsMatrix::get_col(unsigned c)
+TemplatePointsMatrixEntry* TemplatePointsMatrix::get_col(unsigned c)
 {
     return columns[c];
 }
@@ -202,7 +202,7 @@ unsigned TemplatePointsMatrix::height()
 void TemplatePointsMatrix::clear_grade_lists()
 {
     for (unsigned i = 0; i < columns.size(); i++) {
-        std::shared_ptr<TemplatePointsMatrixEntry> cur_entry = columns[i];
+        TemplatePointsMatrixEntry* cur_entry = columns[i];
         while (cur_entry != NULL) {
             cur_entry->low_simplices.clear();
             cur_entry->high_simplices.clear();

--- a/math/template_points_matrix.h
+++ b/math/template_points_matrix.h
@@ -38,11 +38,11 @@ struct TemplatePointsMatrixEntry {
     unsigned y; //discrete y-grade of this support point
     unsigned index; //index of this support point in the vector of support points stored in VisualizationWindow
 
-    std::shared_ptr<TemplatePointsMatrixEntry> down; //pointer to the next support point below this one
-    std::shared_ptr<TemplatePointsMatrixEntry> left; //pointer to the next support point left of this one
+    TemplatePointsMatrixEntry* down; //pointer to the next support point below this one
+    TemplatePointsMatrixEntry* left; //pointer to the next support point left of this one
 
-    std::list<std::shared_ptr<Multigrade>> low_simplices; //associated multigrades for simplices of lower dimension
-    std::list<std::shared_ptr<Multigrade>> high_simplices; //associated multigrades for simplices of higher dimension
+    std::list<Multigrade*> low_simplices; //associated multigrades for simplices of lower dimension
+    std::list<Multigrade*> high_simplices; //associated multigrades for simplices of higher dimension
 
     unsigned low_count; //number of columns in matrix of simplices of lower dimension that are mapped to this TemplatePointsMatrixEntry
     unsigned high_count; //number of columns in matrix of simplices of higher dimension that are mapped to this TemplatePointsMatrixEntry
@@ -52,13 +52,13 @@ struct TemplatePointsMatrixEntry {
 
     //functions
     TemplatePointsMatrixEntry(); //empty constructor
-    TemplatePointsMatrixEntry(unsigned x, unsigned y, unsigned i, std::shared_ptr<TemplatePointsMatrixEntry> d, std::shared_ptr<TemplatePointsMatrixEntry> l); //regular constructor
+    TemplatePointsMatrixEntry(unsigned x, unsigned y, unsigned i, TemplatePointsMatrixEntry* d, TemplatePointsMatrixEntry* l); //regular constructor
     TemplatePointsMatrixEntry(unsigned x, unsigned y); //constructor for temporary entries used in counting switches
 
     void add_multigrade(unsigned x, unsigned y, unsigned num_cols, int index, bool low); //associates a (new) multigrades to this xi entry
     //the "low" argument is true if this multigrade is for low_simplices, and false if it is for high_simplices
 
-    void insert_multigrade(std::shared_ptr<Multigrade> mg, bool low); //inserts a Multigrade at the end of the list for the given dimension; does not update column counts!
+    void insert_multigrade(Multigrade* mg, bool low); //inserts a Multigrade at the end of the list for the given dimension; does not update column counts!
 };
 
 //// each TemplatePointsMatrixEntry maintains two lists of multigrades
@@ -82,20 +82,20 @@ class TemplatePointsMatrix {
 public:
     TemplatePointsMatrix(unsigned width, unsigned height); //constructor
 
-    std::vector<std::shared_ptr<TemplatePointsMatrixEntry>> fill_and_find_anchors(std::vector<TemplatePoint>& xi_pts); //stores xi support points in the xiSupportMatrix
+    std::vector<TemplatePointsMatrixEntry*> fill_and_find_anchors(std::vector<TemplatePoint>& xi_pts); //stores xi support points in the xiSupportMatrix
     //also finds anchors, which are stored both in the matrix and in the vector xi_pts
     //precondition: xi_pts contains the support points in lexicographical order
 
-    std::shared_ptr<TemplatePointsMatrixEntry> get_row(unsigned r); //gets a pointer to the rightmost entry in row r; returns NULL if row r is empty
-    std::shared_ptr<TemplatePointsMatrixEntry> get_col(unsigned c); //gets a pointer to the top entry in column c; returns NULL if column c is empty
+    TemplatePointsMatrixEntry* get_row(unsigned r); //gets a pointer to the rightmost entry in row r; returns NULL if row r is empty
+    TemplatePointsMatrixEntry* get_col(unsigned c); //gets a pointer to the top entry in column c; returns NULL if column c is empty
 
     unsigned height(); //retuns the number of rows;
 
     void clear_grade_lists(); //clears the level set lists for all entries in the matrix
 
 private:
-    std::vector<std::shared_ptr<TemplatePointsMatrixEntry>> columns;
-    std::vector<std::shared_ptr<TemplatePointsMatrixEntry>> rows;
+    std::vector<TemplatePointsMatrixEntry*> columns;
+    std::vector<TemplatePointsMatrixEntry*> rows;
 };
 
 #endif // TEMPLATE_POINT_MATRIX_H

--- a/pointer_comparator.h
+++ b/pointer_comparator.h
@@ -31,7 +31,15 @@ class PointerComparator {
 public:
     Comparator comparator;
 
+    bool operator()(const std::unique_ptr<T> &lhs, const std::unique_ptr<T> &rhs) const //returns true if lhs comes before rhs
+    {
+        return comparator(*lhs, *rhs);
+    }
     bool operator()(const std::shared_ptr<T> lhs, const std::shared_ptr<T> rhs) const //returns true if lhs comes before rhs
+    {
+        return comparator(*lhs, *rhs);
+    }
+    bool operator()(const T* lhs, const T* rhs) const //returns true if lhs comes before rhs
     {
         return comparator(*lhs, *rhs);
     }

--- a/test/serialization_tests.h
+++ b/test/serialization_tests.h
@@ -27,4 +27,45 @@ T round_trip(const T& thing)
     return result;
 }
 
+template <typename T>
+T round_trip_msgpack(const T& thing)
+{
+    std::stringstream ss;
+    msgpack::pack(ss, thing);
+
+    std::string buff(ss.str());
+    T result;
+    auto oh = msgpack::unpack(buff.data(), buff.size());
+    auto obj = oh.get();
+    obj.convert(result);
+    return result;
+}
+
+
+TEST_CASE("InputParameters can be roundtripped with msgpack", "[serialization - msgpack]")
+{
+
+    InputParameters params;
+    params.dim = 0;
+    params.outputFile = "bogus";
+    params.fileName = "inbogus";
+    params.outputFormat = "flergh";
+    params.x_bins = 10;
+    params.y_bins = 10;
+    params.x_label = "x";
+    params.y_label = "y";
+
+    InputParameters result = round_trip_msgpack(params);
+
+    REQUIRE(params.dim == result.dim);
+    REQUIRE(params.fileName == result.fileName);
+    REQUIRE(params.outputFile == result.outputFile);
+    REQUIRE(params.outputFormat == result.outputFormat);
+    REQUIRE(result.outputFormat == "flergh");
+    REQUIRE(params.x_bins == result.x_bins);
+    REQUIRE(params.y_bins == result.y_bins);
+    REQUIRE(params.x_label == result.x_label);
+    REQUIRE(params.y_label == result.y_label);
+
+}
 #endif //RIVET_CONSOLE_SERIALIZATION_TESTS_H_H

--- a/type_tag.h
+++ b/type_tag.h
@@ -25,6 +25,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #ifndef RIVET_CONSOLE_TYPE_TAG_H
 #define RIVET_CONSOLE_TYPE_TAG_H
 
+#include <msgpack.hpp>
+
 //http://www.ilikebigbits.com/blog/2014/5/6/type-safe-identifiers-in-c
 template <class Tag, class impl, impl default_value>
 class ID {
@@ -54,6 +56,8 @@ public:
     {
         ar& m_val;
     }
+
+    MSGPACK_DEFINE(m_val);
 
 private:
     impl m_val;


### PR DESCRIPTION
* Create a rivet.a static library
* Beginnings of C++ and C api in that library, which is then used by rivet_console and is suitable for use in long-running systems
* Add support for msgpack-based serialization, which tends to generate files that are about half the size of those generated by boost-based serialization. 
* Replace most uses of smart pointers within Arrangement and related classes, which addresses a significant memory leak that arises when using RIVET in a long-running process as opposed to doing a single calculation and exiting.