### PR TITLE
Implement Load New Data Feature

### DIFF
--- a/dataselectdialog.cpp
+++ b/dataselectdialog.cpp
@@ -66,8 +66,10 @@ void DataSelectDialog::closeEvent(QCloseEvent* event)
 {
     event->accept();
 
-    if (!data_selected)
+    if (!data_selected) {
         qobject_cast<QWidget*>(this->parent())->close();
+        exit(0);
+    }
 }
 
 void DataSelectDialog::on_computeButton_clicked()

--- a/interface/c_api.cpp
+++ b/interface/c_api.cpp
@@ -34,7 +34,7 @@ extern "C" RivetComputationResult read_rivet_computation(const char* bytes, size
 extern "C" void free_rivet_computation_result(RivetComputationResult result)
 {
     if (result.computation != nullptr) {
-        delete reinterpret_cast<ComputationResult *>(result.computation);
+        delete reinterpret_cast<ComputationResult*>(result.computation);
     } else {
         delete[] result.error;
     }
@@ -67,7 +67,7 @@ extern "C" BarCodesResult barcodes_from_computation(RivetComputation* rivet_comp
             barcodes[i].angle = angles[i];
             barcodes[i].offset = offsets[i];
         }
-//        Bounds bounds = compute_bounds(*computation);
+        //        Bounds bounds = compute_bounds(*computation);
         result.barcodes = barcodes;
         result.length = query_results.size();
         result.error = nullptr;
@@ -108,8 +108,7 @@ extern "C" void free_barcodes_result(BarCodesResult result)
     }
 }
 
-
-extern "C" StructurePoints * structure_from_computation(RivetComputation* rivet_computation)
+extern "C" StructurePoints* structure_from_computation(RivetComputation* rivet_computation)
 {
     ComputationResult* computation = reinterpret_cast<ComputationResult*>(rivet_computation);
     auto x_exact = new Ratio[computation->arrangement->x_exact.size()];
@@ -146,7 +145,8 @@ extern "C" StructurePoints * structure_from_computation(RivetComputation* rivet_
     return result;
 }
 
-void free_structure_points(StructurePoints *points) {
+void free_structure_points(StructurePoints* points)
+{
     delete[] points->grades->x_grades;
     delete[] points->grades->y_grades;
     delete points->grades;

--- a/interface/c_api.h
+++ b/interface/c_api.h
@@ -40,7 +40,7 @@ typedef struct {
 typedef struct {
     BarCode* barcodes;
     size_t length;
-    char * error;
+    char* error;
     size_t error_length;
 } BarCodesResult;
 
@@ -80,9 +80,9 @@ typedef struct {
 } Ratio;
 
 typedef struct {
-    Ratio *x_grades;
+    Ratio* x_grades;
     size_t x_length;
-    Ratio *y_grades;
+    Ratio* y_grades;
     size_t y_length;
 } ExactGrades;
 
@@ -95,15 +95,14 @@ typedef struct {
 } StructurePoint;
 
 typedef struct {
-    ExactGrades *grades;
-    StructurePoint *points;
+    ExactGrades* grades;
+    StructurePoint* points;
     size_t length;
 } StructurePoints;
 
-StructurePoints * structure_from_computation(RivetComputation* rivet_computation);
+StructurePoints* structure_from_computation(RivetComputation* rivet_computation);
 
-void free_structure_points(StructurePoints *points);
-
+void free_structure_points(StructurePoints* points);
 }
 
 #endif //RIVET_CONSOLE_C_API_H

--- a/interface/configuredialog.cpp
+++ b/interface/configuredialog.cpp
@@ -121,7 +121,7 @@ ConfigureDialog::~ConfigureDialog()
 
 void ConfigureDialog::closeEvent(QCloseEvent* event)
 {
-    emit window_closed();
+    emit window_closed(); // tells visualization window to check for changes and redraw
     QDialog::closeEvent(event);
 }
 

--- a/interface/configuredialog.cpp
+++ b/interface/configuredialog.cpp
@@ -119,6 +119,12 @@ ConfigureDialog::~ConfigureDialog()
     delete ui;
 }
 
+void ConfigureDialog::closeEvent(QCloseEvent* event)
+{
+    emit window_closed();
+    QDialog::closeEvent(event);
+}
+
 void ConfigureDialog::on_cancelButton_clicked()
 {
     close();

--- a/interface/configuredialog.h
+++ b/interface/configuredialog.h
@@ -41,6 +41,10 @@ class ConfigureDialog : public QDialog {
 public:
     explicit ConfigureDialog(ConfigParameters& c_params, InputParameters& i_params, QWidget* parent = 0);
     ~ConfigureDialog();
+    void closeEvent(QCloseEvent* event);
+
+signals:
+    void window_closed();
 
 private slots:
     void on_cancelButton_clicked();

--- a/interface/control_dot.cpp
+++ b/interface/control_dot.cpp
@@ -56,11 +56,9 @@ void ControlDot::paint(QPainter* painter, const QStyleOptionGraphicsItem* /*unus
     QRectF rect = boundingRect();
     QBrush brush(config_params->sliceLineColor);
 
-    if(!slice_line->is_inside_view())
-    {
+    if (!slice_line->is_inside_view()) {
         brush.setColor(Qt::gray);
-    }
-    else if (pressed) {
+    } else if (pressed) {
         brush.setColor(config_params->sliceLineHighlightColor);
     }
 
@@ -74,8 +72,7 @@ QVariant ControlDot::itemChange(GraphicsItemChange change, const QVariant& value
 {
     if (change == QGraphicsItem::ItemPositionChange && !update_lock) {
 
-
-        if(!slice_line->is_inside_view()){
+        if (!slice_line->is_inside_view()) {
             //then don't allow the user to drag the dot
             return pos();
         }
@@ -165,7 +162,7 @@ void ControlDot::set_position(const QPointF& newpos)
 
 void ControlDot::mousePressEvent(QGraphicsSceneMouseEvent* event)
 {
-    if(!slice_line->is_inside_view()){
+    if (!slice_line->is_inside_view()) {
         return;
     }
     pressed = true;
@@ -177,7 +174,7 @@ void ControlDot::mousePressEvent(QGraphicsSceneMouseEvent* event)
 
 void ControlDot::mouseReleaseEvent(QGraphicsSceneMouseEvent* event)
 {
-    if(!slice_line->is_inside_view()){
+    if (!slice_line->is_inside_view()) {
         return;
     }
     pressed = false;

--- a/interface/persistence_diagram.cpp
+++ b/interface/persistence_diagram.cpp
@@ -48,6 +48,17 @@ PersistenceDiagram::PersistenceDiagram(ConfigParameters* params, QObject* parent
     setItemIndexMethod(NoIndex); //not sure why, but this seems to fix the dot update issue (#7 in the issue tracker)
 }
 
+void PersistenceDiagram::reset(ConfigParameters* params, QObject* parent)
+{
+    clear();
+    all_dots.clear();
+    dots_by_bc_index.clear();
+    selected = NULL;
+    barcode = new Barcode();
+
+    // PersistenceDiagram(params, parent);
+}
+
 //simply creates all objects; resize_diagram() handles positioning of objects
 void PersistenceDiagram::create_diagram()
 {

--- a/interface/persistence_diagram.cpp
+++ b/interface/persistence_diagram.cpp
@@ -48,15 +48,14 @@ PersistenceDiagram::PersistenceDiagram(ConfigParameters* params, QObject* parent
     setItemIndexMethod(NoIndex); //not sure why, but this seems to fix the dot update issue (#7 in the issue tracker)
 }
 
-void PersistenceDiagram::reset(ConfigParameters* params, QObject* parent)
+// resets data structures and variables to draw new diagram
+void PersistenceDiagram::reset()
 {
     clear();
     all_dots.clear();
     dots_by_bc_index.clear();
     selected = NULL;
     barcode = new Barcode();
-
-    // PersistenceDiagram(params, parent);
 }
 
 //simply creates all objects; resize_diagram() handles positioning of objects
@@ -552,7 +551,7 @@ void PersistenceDiagram::update_diagram(double slice_length_pix, double diagram_
     if (is_visible) {
         line_size = slice_length_pix / sqrt(2); //divide by sqrt(2) because the line is drawn at a 45-degree angle
     } else {
-        line_size=0;
+        line_size = 0;
     }
     dist_to_origin = slice_dist_dat;
     scale = diagram_scale / sqrt(2); //similarly to line_size, divide by sqrt(2)

--- a/interface/persistence_diagram.h
+++ b/interface/persistence_diagram.h
@@ -52,7 +52,7 @@ public:
     void deselect_dot(); //remove selection and propagate to the slice diagram
 
     void receive_parameter_change(); //updates the diagram after a change in the configuration parameters
-    void reset(ConfigParameters* params, QObject* parent);
+    void reset(); // clears up data structures and variable values
 
 public slots:
     void receive_dot_selection(unsigned index); //highlight the specified dot, which has been selected externally

--- a/interface/persistence_diagram.h
+++ b/interface/persistence_diagram.h
@@ -52,6 +52,7 @@ public:
     void deselect_dot(); //remove selection and propagate to the slice diagram
 
     void receive_parameter_change(); //updates the diagram after a change in the configuration parameters
+    void reset(ConfigParameters* params, QObject* parent);
 
 public slots:
     void receive_dot_selection(unsigned index); //highlight the specified dot, which has been selected externally

--- a/interface/progressdialog.cpp
+++ b/interface/progressdialog.cpp
@@ -85,8 +85,7 @@ void ProgressDialog::updateProgress(unsigned current)
 void ProgressDialog::setComputationFinished()
 {
     computation_finished = true;
-    QThread::msleep(200); //seems to prevent ProgressDialog from sticking around after it is supposed to have been closed
-    done(0);
+    close();
 }
 
 void ProgressDialog::closeEvent(QCloseEvent* event)

--- a/interface/slice_diagram.cpp
+++ b/interface/slice_diagram.cpp
@@ -58,6 +58,26 @@ SliceDiagram::~SliceDiagram()
     clear(); //removes and deletes all items from the QGraphicsScene
 }
 
+void SliceDiagram::reset(ConfigParameters* params, std::vector<double>& x_grades, std::vector<double>& y_grades, QObject* parent)
+{
+    clear();
+    xi0_dots.clear();
+    xi1_dots.clear();
+    xi2_dots.clear();
+    bars.clear();
+    primary_selected.clear();
+    secondary_selected.clear();
+    points.clear();
+    hom_dim_rects.resize(boost::extents[0][0]);
+    dot_left = nullptr;
+    dot_right = nullptr;
+    slice_line = nullptr;
+    max_xi_value = 0;
+    line_visible = true;
+    created = false;
+    control_dot_moved = false;
+}
+
 //receives an xi support point, which will be drawn when create_diagram() is called
 void SliceDiagram::add_point(double x_coord, double y_coord, int xi0m, int xi1m, int xi2m)
 {

--- a/interface/slice_diagram.cpp
+++ b/interface/slice_diagram.cpp
@@ -58,7 +58,8 @@ SliceDiagram::~SliceDiagram()
     clear(); //removes and deletes all items from the QGraphicsScene
 }
 
-void SliceDiagram::reset(ConfigParameters* params, std::vector<double>& x_grades, std::vector<double>& y_grades, QObject* parent)
+// resets data structures and variables to draw new diagram
+void SliceDiagram::reset()
 {
     clear();
     xi0_dots.clear();
@@ -556,7 +557,7 @@ void SliceDiagram::zoom_diagram(double angle, double offset, double distance_to_
     if (line_vert) {
         double relative_intercept_horz = (-offset - data_xmin) / (data_xmax - data_xmin); //vertical line has negative offset
         x = relative_intercept_horz * diagram_width;
-        line_visible = (0 <= relative_intercept_horz && relative_intercept_horz <= 1+float(padding)/diagram_width);
+        line_visible = (0 <= relative_intercept_horz && relative_intercept_horz <= 1 + float(padding) / diagram_width);
         slice_line->update_position(x, y, line_vert, 0);
         slice_line->set_visibility(line_visible); //don't plot the line if it lies outisde of the viewing window
         line_pos = -1 * relative_intercept_horz;
@@ -570,12 +571,12 @@ void SliceDiagram::zoom_diagram(double angle, double offset, double distance_to_
             double relative_intercept_horz = -data_xmin + (data_ymin - intrinsic_y_int) / (intrinsic_slope);
             relative_intercept_horz /= data_xmax - data_xmin;
             x = relative_intercept_horz * diagram_width;
-            line_visible = relative_intercept_horz < 1+float(padding)/diagram_width;
+            line_visible = relative_intercept_horz < 1 + float(padding) / diagram_width;
             line_pos = -1 * relative_intercept_horz;
         } else //then left-bottom endpoint is along left edge of box
         {
             y = relative_intercept_vert * diagram_height;
-            line_visible = relative_intercept_vert < 1+float(padding)/diagram_height;
+            line_visible = relative_intercept_vert < 1 + float(padding) / diagram_height;
             line_pos = relative_intercept_vert;
         }
 
@@ -709,7 +710,7 @@ void SliceDiagram::update_line(double angle, double offset, double distance_to_o
         line_vert = true;
         line_pos = offset / (data_xmax - data_xmin); //relative units
 
-        line_visible = (-1 <= line_pos && line_pos <= float(padding)/diagram_width); //vertical line has negative offset
+        line_visible = (-1 <= line_pos && line_pos <= float(padding) / diagram_width); //vertical line has negative offset
 
         //update the SliceLine
 
@@ -723,7 +724,7 @@ void SliceDiagram::update_line(double angle, double offset, double distance_to_o
         line_vert = false;
         line_slope = 0;
         line_pos = offset / (data_ymax - data_ymin); //relative units
-        line_visible = (0 <= line_pos && line_pos <= 1+float(padding)/diagram_height);
+        line_visible = (0 <= line_pos && line_pos <= 1 + float(padding) / diagram_height);
 
         //update the SliceLine
         int ypos = (offset - data_ymin) * scale_y; //pixel units
@@ -741,14 +742,14 @@ void SliceDiagram::update_line(double angle, double offset, double distance_to_o
         if (y_coord >= data_ymin) //then slice line intersects left edge of box
         {
             line_pos = (y_coord - data_ymin) / (data_ymax - data_ymin); //relative units
-            line_visible = line_pos < 1+float(padding)/diagram_height;
+            line_visible = line_pos < 1 + float(padding) / diagram_height;
             slice_line->update_position(0, (y_coord - data_ymin) * scale_y, false, line_slope * scale_y / scale_x);
 
         } else //then slice line intersects bottom of box
         {
             double x_coord = (data_ymin - offset / cos(radians)) / line_slope; //x-coordinate of slice line at y=data_ymin; data units
             line_pos = -1 * (x_coord - data_xmin) / (data_xmax - data_xmin); //relative units
-            line_visible = -1 -float(padding)/diagram_width< line_pos;
+            line_visible = -1 - float(padding) / diagram_width < line_pos;
 
             slice_line->update_position((x_coord - data_xmin) * scale_x, 0, false, line_slope * scale_y / scale_x);
         }
@@ -923,7 +924,7 @@ std::pair<double, double> SliceDiagram::compute_endpoint(double coordinate, unsi
         if (coordinate == std::numeric_limits<double>::infinity() || coordinate * std::min(scale_x, scale_y) > pow(10.0, 7.0)) {
             //set coordinate so that it will be outside the viewable window
             //the finite cutoff seems to patch over the issue with phantom barcodes-not sure why
-            coordinate = dist_to_origin+view_length / std::min(scale_x, scale_y);
+            coordinate = dist_to_origin + view_length / std::min(scale_x, scale_y);
         }
 
         //find (x,y) along the line

--- a/interface/slice_diagram.h
+++ b/interface/slice_diagram.h
@@ -105,7 +105,7 @@ public:
     int get_diagram_width() { return diagram_width; }; //the width of the above region corresponding to the displayed window bounds
     int get_diagram_height() { return diagram_height; };
 
-    void reset(ConfigParameters* params, std::vector<double>& x_grades, std::vector<double>& y_grades, QObject* parent);
+    void reset(); // clears up data structures and variable values
 
 public slots:
     void receive_bar_selection(std::vector<unsigned> indexes); //highlight the specified class of bars, which has been selected externally

--- a/interface/slice_diagram.h
+++ b/interface/slice_diagram.h
@@ -105,6 +105,8 @@ public:
     int get_diagram_width() { return diagram_width; }; //the width of the above region corresponding to the displayed window bounds
     int get_diagram_height() { return diagram_height; };
 
+    void reset(ConfigParameters* params, std::vector<double>& x_grades, std::vector<double>& y_grades, QObject* parent);
+
 public slots:
     void receive_bar_selection(std::vector<unsigned> indexes); //highlight the specified class of bars, which has been selected externally
     void receive_bar_secondary_selection(std::vector<unsigned> indexes); //secondary highlight, used for persistence dots that represent multiple classes of bars

--- a/interface/slice_line.cpp
+++ b/interface/slice_line.cpp
@@ -67,10 +67,9 @@ void SliceLine::paint(QPainter* painter, const QStyleOptionGraphicsItem* /*unuse
     QPen pen(config_params->sliceLineColor);
     pen.setWidth(config_params->sliceLineWidth);
 
-    if(!inside_view){
+    if (!inside_view) {
         pen.setColor(Qt::gray);
-    }
-    else if (pressed) {
+    } else if (pressed) {
         pen.setColor(config_params->sliceLineHighlightColor);
     }
 
@@ -101,8 +100,7 @@ void SliceLine::paint(QPainter* painter, const QStyleOptionGraphicsItem* /*unuse
 //left-click and drag to move line, maintaining the same slope
 QVariant SliceLine::itemChange(GraphicsItemChange change, const QVariant& value)
 {
-    if(!inside_view)
-    {//then don't allow the line to be moved
+    if (!inside_view) { //then don't allow the line to be moved
         return QGraphicsItem::itemChange(change, value);
     }
     if (change == QGraphicsItem::ItemPositionChange && !update_lock) {
@@ -308,7 +306,7 @@ void SliceLine::update_position(double xpos, double ypos, bool vert, double pixe
 
 void SliceLine::mousePressEvent(QGraphicsSceneMouseEvent* event)
 {
-    if(!inside_view){
+    if (!inside_view) {
         return;
     }
     if (event->button() == Qt::RightButton) {
@@ -325,7 +323,7 @@ void SliceLine::mousePressEvent(QGraphicsSceneMouseEvent* event)
 
 void SliceLine::mouseReleaseEvent(QGraphicsSceneMouseEvent* event)
 {
-    if(!inside_view){
+    if (!inside_view) {
         return;
     }
     if (event->button() == Qt::RightButton) {
@@ -343,7 +341,7 @@ void SliceLine::mouseReleaseEvent(QGraphicsSceneMouseEvent* event)
 //right-click and drag to change slope, left/bottom endpoint stays fixed
 void SliceLine::mouseMoveEvent(QGraphicsSceneMouseEvent* event)
 {
-    if(!inside_view){
+    if (!inside_view) {
         return;
     }
     if (rotating) {
@@ -419,7 +417,5 @@ bool SliceLine::is_inside_view()
 
 void SliceLine::set_visibility(bool visible)
 {
-    inside_view=visible;
-
-
+    inside_view = visible;
 }

--- a/interface/slice_line.h
+++ b/interface/slice_line.h
@@ -63,6 +63,7 @@ public:
 
     void set_visibility(bool visible);
     bool is_inside_view();
+
 protected:
     void mousePressEvent(QGraphicsSceneMouseEvent* event);
     void mouseReleaseEvent(QGraphicsSceneMouseEvent* event);
@@ -87,7 +88,7 @@ private:
     SliceDiagram* sdgm;
     ConfigParameters* config_params;
 
-    bool inside_view=true;
+    bool inside_view = true;
     void compute_right_point(); //sets correct position of right_point, given slope of line and position of left point
 };
 

--- a/math/presentation.cpp
+++ b/math/presentation.cpp
@@ -371,9 +371,9 @@ void Presentation::minimize(int verbosity)
             //mark pivot_i for removal from row indices
             new_row_indices[pivot_i] = -1;
 
-            //zero out the part of the row pivot_i to the right of i.
-            //The part of the row to the left is already zero.
-            #pragma omp parallel for
+//zero out the part of the row pivot_i to the right of i.
+//The part of the row to the left is already zero.
+#pragma omp parallel for
             for (unsigned j = i + 1; j < mat.width(); j++) {
 
                 if (mat.entry_sorted(pivot_i, j)) {

--- a/visualizationwindow.cpp
+++ b/visualizationwindow.cpp
@@ -59,8 +59,6 @@ VisualizationWindow::VisualizationWindow(InputParameters& params)
     , template_points()
     , degenerate_x(false)
     , degenerate_y(false)
-    , cthread(input_params)
-    , prog_dialog(this)
     , line_selection_ready(false)
     , slice_diagram(&config_params, grades.x, grades.y, this)
     , slice_update_lock(false)
@@ -68,6 +66,8 @@ VisualizationWindow::VisualizationWindow(InputParameters& params)
     , persistence_diagram_drawn(false)
     , slice_diagram_initialized(false)
 {
+    cthread = new ComputationThread(input_params);
+    prog_dialog = new ProgressDialog(this);
     ui->setupUi(this);
 
     //set up the slice diagram
@@ -85,16 +85,15 @@ VisualizationWindow::VisualizationWindow(InputParameters& params)
 
 
     //connect signal from DataSelectDialog to start the computation
-    QObject::connect(&ds_dialog, &DataSelectDialog::dataSelected, this, &VisualizationWindow::start_computation);
+    QObject::connect(&ds_dialog, &DataSelectDialog::dataSelected, this, &VisualizationWindow::init);
 
     //connect signals from ComputationThread to slots in VisualizationWindow
-    QObject::connect(&cthread, &ComputationThread::advanceProgressStage, &prog_dialog, &ProgressDialog::advanceToNextStage);
-    QObject::connect(&cthread, &ComputationThread::setProgressMaximum, &prog_dialog, &ProgressDialog::setStageMaximum);
-    QObject::connect(&cthread, &ComputationThread::setCurrentProgress, &prog_dialog, &ProgressDialog::updateProgress);
-    QObject::connect(&cthread, &ComputationThread::templatePointsReady, this, &VisualizationWindow::paint_template_points);
-    QObject::connect(&cthread, &ComputationThread::arrangementReady, this, &VisualizationWindow::augmented_arrangement_ready);
-    QObject::connect(&cthread, &ComputationThread::finished, &prog_dialog, &ProgressDialog::setComputationFinished);
-
+    QObject::connect(cthread, &ComputationThread::advanceProgressStage, prog_dialog, &ProgressDialog::advanceToNextStage);
+    QObject::connect(cthread, &ComputationThread::setProgressMaximum, prog_dialog, &ProgressDialog::setStageMaximum);
+    QObject::connect(cthread, &ComputationThread::setCurrentProgress, prog_dialog, &ProgressDialog::updateProgress);
+    QObject::connect(cthread, &ComputationThread::templatePointsReady, this, &VisualizationWindow::paint_template_points);
+    QObject::connect(cthread, &ComputationThread::arrangementReady, this, &VisualizationWindow::augmented_arrangement_ready);
+    
     //connect signals and slots for the diagrams
     QObject::connect(&slice_diagram, &SliceDiagram::set_line_control_elements, this, &VisualizationWindow::set_line_parameters);
     QObject::connect(&slice_diagram, &SliceDiagram::persistence_bar_selected, &p_diagram, &PersistenceDiagram::receive_dot_selection);
@@ -104,14 +103,25 @@ VisualizationWindow::VisualizationWindow(InputParameters& params)
     QObject::connect(&p_diagram, &PersistenceDiagram::persistence_dot_secondary_selection, &slice_diagram, &SliceDiagram::receive_bar_secondary_selection);
     QObject::connect(&p_diagram, &PersistenceDiagram::persistence_dot_deselected, &slice_diagram, &SliceDiagram::receive_bar_deselection);
 
-
     //connect other signals and slots
-    QObject::connect(&prog_dialog, &ProgressDialog::stopComputation, &cthread, &ComputationThread::terminate); ///TODO: don't use QThread::terminate()! modify ComputationThread so that it can stop gracefully and clean up after itself
+    QObject::connect(prog_dialog, &ProgressDialog::stopComputation, cthread, &ComputationThread::terminate); ///TODO: don't use QThread::terminate()! modify ComputationThread so that it can stop gracefully and clean up after itself
 }
 
 VisualizationWindow::~VisualizationWindow()
 {
     delete ui;
+}
+
+void VisualizationWindow::reset_window()
+{
+    prog_dialog = new ProgressDialog(this);
+
+    //reconnect signals related to prog_dialog
+    QObject::connect(cthread, &ComputationThread::advanceProgressStage, prog_dialog, &ProgressDialog::advanceToNextStage);
+    QObject::connect(cthread, &ComputationThread::setProgressMaximum, prog_dialog, &ProgressDialog::setStageMaximum);
+    QObject::connect(cthread, &ComputationThread::setCurrentProgress, prog_dialog, &ProgressDialog::updateProgress);
+    
+    QObject::connect(prog_dialog, &ProgressDialog::stopComputation, cthread, &ComputationThread::terminate);
 }
 
 void VisualizationWindow::redraw()
@@ -127,18 +137,47 @@ void VisualizationWindow::redraw()
     delete configBox;
 }
 
+void VisualizationWindow::init()
+{
+    if (template_points)
+        template_points = NULL;
+
+    if (arrangement)
+        arrangement = NULL;
+
+    if (barcode)
+        barcode.release();
+
+    template_points = std::shared_ptr<TemplatePointsMessage>();
+    arrangement = std::shared_ptr<ArrangementMessage>();
+    barcode = std::unique_ptr<Barcode>();
+    grades = Grades();
+    slice_diagram.reset(&config_params, grades.x, grades.y, this);
+    p_diagram.reset(&config_params, this);
+
+    x_reverse = false;
+    y_reverse = false;
+    degenerate_x = false;
+    degenerate_y = false;
+    line_selection_ready = false;
+    persistence_diagram_drawn = false;
+    slice_diagram_initialized = false;
+
+    start_computation();
+}
+
 //slot that starts the persistent homology computation in a new thread
 void VisualizationWindow::start_computation()
 {
     data_selected = true;
 
     //show the progress box
-    prog_dialog.show();
-    prog_dialog.activateWindow();
-    prog_dialog.raise();
+    prog_dialog->show();
+    prog_dialog->activateWindow();
+    prog_dialog->raise();
 
     //start the computation in a new thread
-    cthread.compute();
+    cthread->compute();
 
     //update text items
     auto shortName = QString::fromStdString(input_params.shortName);
@@ -153,7 +192,6 @@ void VisualizationWindow::start_computation()
 void VisualizationWindow::paint_template_points(std::shared_ptr<TemplatePointsMessage> points)
 {
     qDebug() << "VisualizationWindow: Received template points";
-
 
     x_reverse=points->x_reverse;
     y_reverse=points->y_reverse;
@@ -215,7 +253,6 @@ void VisualizationWindow::paint_template_points(std::shared_ptr<TemplatePointsMe
             initial_xmax=grades.x.back();
             initial_ymax=grades.y.back();
         }
-
 
         //set absolute bounds on the maximum/minimum window scroll boxes, to prevent numerical issues
 
@@ -301,10 +338,6 @@ void VisualizationWindow::paint_template_points(std::shared_ptr<TemplatePointsMe
 
 
 
-
-
-
-
     //update offset extents
     ///TODO: maybe these extents should be updated dynamically, based on the slope of the slice line
     ui->offsetSpinBox->setMinimum(grades.min_offset());
@@ -313,6 +346,7 @@ void VisualizationWindow::paint_template_points(std::shared_ptr<TemplatePointsMe
 
     //update status
     line_selection_ready = true;
+
   //  ui->statusBar->showMessage("bigraded Betti number visualization ready"); STATUS BAR CURRENTLY DISABLED
 }
 
@@ -387,6 +421,11 @@ void VisualizationWindow::augmented_arrangement_ready(std::shared_ptr<Arrangemen
         //Have to rely on console to either a) always save (to tmp file if needed), or b) tell us filetype in the output.
         //    else if(input_params.raw_data)
         //        unsaved_data = true;
+    }
+
+    if (prog_dialog) {
+        prog_dialog->setComputationFinished();
+        delete prog_dialog;
     }
 } //end augmented_arrangement_ready()
 
@@ -823,13 +862,11 @@ void VisualizationWindow::save_arrangement(const QString& filename)
 
 void VisualizationWindow::on_actionOpen_triggered()
 {
-    ///TODO: get user confirmation and clear the existing data structures
+    ///TODO: get user confirmation
+    reset_window();
+    data_selected = false;
+    ds_dialog.exec();
 
-    QMessageBox msgBox;
-    msgBox.setText("This feature is not implemented yet.");
-    msgBox.exec();
-
-    ///TODO: open the data select dialog box and load new data
 } //end on_actionOpen_triggered()
 
 

--- a/visualizationwindow.cpp
+++ b/visualizationwindow.cpp
@@ -114,7 +114,18 @@ VisualizationWindow::~VisualizationWindow()
     delete ui;
 }
 
+void VisualizationWindow::redraw()
+{
+    if (line_selection_ready) {
+        slice_diagram.receive_parameter_change();
 
+        if (persistence_diagram_drawn)
+            p_diagram.receive_parameter_change();
+    }
+    
+    QObject::disconnect(configBox, &ConfigureDialog::window_closed, this, &VisualizationWindow::redraw);
+    delete configBox;
+}
 
 //slot that starts the persistent homology computation in a new thread
 void VisualizationWindow::start_computation()
@@ -751,16 +762,9 @@ void VisualizationWindow::on_actionAbout_triggered()
 void VisualizationWindow::on_actionConfigure_triggered()
 {
     configBox = new ConfigureDialog(config_params, input_params, this);
-    configBox->exec();
+    configBox->show();
 
-    if (line_selection_ready) {
-        slice_diagram.receive_parameter_change();
-
-        if (persistence_diagram_drawn)
-            p_diagram.receive_parameter_change();
-    }
-
-    delete configBox;
+    QObject::connect(configBox, &ConfigureDialog::window_closed, this, &VisualizationWindow::redraw);
 }
 
 void VisualizationWindow::on_actionSave_persistence_diagram_as_image_triggered()

--- a/visualizationwindow.h
+++ b/visualizationwindow.h
@@ -163,8 +163,6 @@ private:
     //other items
     void save_arrangement(const QString& filename);
 
-    void reset_window();
-
     AboutMessageBox aboutBox; //which is better for these dialog boxes
     ConfigureDialog* configBox; // -- pointer or no pointer?
 };

--- a/visualizationwindow.h
+++ b/visualizationwindow.h
@@ -69,6 +69,9 @@ public slots:
     void augmented_arrangement_ready(std::shared_ptr<ArrangementMessage> arrangement);
     void set_line_parameters(double angle, double offset);
 
+    void redraw();
+    void init();
+
 private slots:
     void on_angleDoubleSpinBox_valueChanged(double angle);
     void on_offsetSpinBox_valueChanged(double arg1);
@@ -141,8 +144,8 @@ private:
     bool degenerate_x,degenerate_y; //these are true if there is exactly one x/y grade
 
     //computation items
-    ComputationThread cthread;
-    ProgressDialog prog_dialog;
+    ComputationThread* cthread;
+    ProgressDialog* prog_dialog;
 
     //items for slice diagram
     bool line_selection_ready; //initially false, but set to true when data is in place for line selection
@@ -159,7 +162,8 @@ private:
     void update_origin();//computes the origin of the line after a change in parameters; updates the value of dist_to_origin
     //other items
     void save_arrangement(const QString& filename);
-    void redraw();
+
+    void reset_window();
 
     AboutMessageBox aboutBox; //which is better for these dialog boxes
     ConfigureDialog* configBox; // -- pointer or no pointer?

--- a/visualizationwindow.h
+++ b/visualizationwindow.h
@@ -159,6 +159,7 @@ private:
     void update_origin();//computes the origin of the line after a change in parameters; updates the value of dist_to_origin
     //other items
     void save_arrangement(const QString& filename);
+    void redraw();
 
     AboutMessageBox aboutBox; //which is better for these dialog boxes
     ConfigureDialog* configBox; // -- pointer or no pointer?


### PR DESCRIPTION
This pull request addresses multiple issues:

resolves #114 
resolves #31 
resolves #6 

It also makes the configure dialog movable without moving the entire visualization window.
The configure dialog and progress dialog are created dynamically and deleted when their use if over.