### PR TITLE
use a color-blind friendly palatte

### DIFF
--- a/interface/config_parameters.cpp
+++ b/interface/config_parameters.cpp
@@ -22,13 +22,13 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 //default values are set here
 ConfigParameters::ConfigParameters()
-    : xi0color(0, 255, 0, 100) //green semi-transparent, for xi_0 support dots
-    , xi1color(255, 0, 0, 100) //red semi-transparent, for xi_1 support dots
-    , xi2color(255, 255, 0, 100) //yellow semi-transparent, for xi_2 support dots
-    , persistenceColor(160, 0, 200, 127) //purple semi-transparent, for persistence bars and dots
-    , persistenceHighlightColor(255, 140, 0, 150) //orange semi-transparent, for highlighting part of the slice line
-    , sliceLineColor(0, 0, 255, 150) //blue semi-transparent, for slice line
-    , sliceLineHighlightColor(0, 200, 200, 150) //cyan semi-transparent, for highlighting the slice line on click-and-drag
+    : xi0color(0, 158, 115, 128) //blueish-green semi-transparent, for xi_0 support dots
+    , xi1color(213, 94, 0, 128) //vermillion semi-transparent, for xi_1 support dots
+    , xi2color(240, 228, 66, 128) //yellow semi-transparent, for xi_2 support dots
+    , persistenceColor(204, 121, 167, 192) //reddish-purple semi-transparent, for persistence bars and dots
+    , persistenceHighlightColor(230, 159, 0, 192) //orange semi-transparent, for highlighting part of the slice line
+    , sliceLineColor(0, 114, 178, 192) //blue semi-transparent, for slice line
+    , sliceLineHighlightColor(86, 180, 233, 192) //sky-blue semi-transparent, for highlighting the slice line on click-and-drag
     , bettiDotRadius(5) //radius of dot representing xi_0 = 1 or xi_1 = 1
     , persistenceDotRadius(5) //radius of dot representing one homology class in persistence diagram
     , autoDotSize(true) //automatic dot sizing is initially on


### PR DESCRIPTION
Changed the colors in the interface to be colorblind accessible using [Bang Wong's 7-color palette](https://www.nature.com/articles/nmeth.1618). Also upped the opacity a bit since the new palette is less vibrant. 

![screenshot](https://user-images.githubusercontent.com/10717115/83958100-db4f8e80-a822-11ea-8be4-4f4722810819.png)


