### PR TITLE
Fix compilation under newer compilers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ externalproject_add(
   docopt_project
   PREFIX docopt
   GIT_REPOSITORY https://github.com/docopt/docopt.cpp
-  GIT_TAG a4177ccf1a6e36ebe268972732ddd456a3574f6d
+  GIT_TAG 6f5de76970be94a6f1e4556d1716593100e285d2
   CMAKE_ARGS -D CMAKE_CXX_STANDARD=11 -D CMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
   INSTALL_COMMAND ""
   )
@@ -133,7 +133,7 @@ add_executable (rivet_console
 
 add_dependencies(rivet_console docopt_project msgpack_project)
 
-target_link_libraries(rivet_console ${CMAKE_CURRENT_BINARY_DIR}/docopt/src/docopt_project-build/libdocopt_s.a ${Boost_LIBRARIES})
+target_link_libraries(rivet_console ${CMAKE_CURRENT_BINARY_DIR}/docopt/src/docopt_project-build/libdocopt.a ${Boost_LIBRARIES})
 # TODO: Make this file run the qmake build as well, and copy the rivet_console into the same dir where the viewer is built
 # TODO: make this not recompile everything we just compiled for rivet_console.
 # Maybe using https://cmake.org/Wiki/CMake/Tutorials/Object_Library ?


### PR DESCRIPTION
Newer GCC versions, at least those greater than or equal to 10.0, fail
to compile the project because they cannot find std::runtime_error when
compiling docopt.

This was fixed in docopt at commit docopt/docopt.cpp@1ae5cd6
In this pull request we bump the docopt version to fix the issue here.

I have also changed the reference to the compiled docopt library, as it was
different on my machine, maybe also due to a change of versions.

I have tested it under cmake 3.21.3 and GCC 11.1.0 in Archlinux. Older
versions were not tested and may fail to compile.